### PR TITLE
Added basic token authorization framework.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,16 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <!-- Firebase -->
+        <dependency>
+            <groupId>com.google.firebase</groupId>
+            <artifactId>firebase-admin</artifactId>
+            <version>6.11.0</version>
+        </dependency>
         <!-- Common Libs -->
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/java/dev/codesupport/web/api/service/UserService.java
+++ b/src/main/java/dev/codesupport/web/api/service/UserService.java
@@ -7,6 +7,7 @@ import dev.codesupport.web.api.data.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.security.RolesAllowed;
 import java.util.Collections;
 import java.util.List;
 
@@ -33,14 +34,18 @@ public class UserService {
         return userCrudOperations.getAll();
     }
 
+    //TODO: Would be better if roles could be defined on an interface.
+    @RolesAllowed("ROLE_ADMIN")
     public List<User> createUsers(List<User> users) {
         return userCrudOperations.createEntities(users);
     }
 
+    @RolesAllowed("ROLE_ADMIN")
     public List<User> updateUsers(List<User> users) {
         return userCrudOperations.updateEntities(users);
     }
 
+    @RolesAllowed("ROLE_ADMIN")
     public List<User> deleteUsers(List<User> users) {
         userCrudOperations.deleteEntities(users);
         //TODO: What should this return?

--- a/src/main/java/dev/codesupport/web/common/configuration/FirebaseAuthenticationProvider.java
+++ b/src/main/java/dev/codesupport/web/common/configuration/FirebaseAuthenticationProvider.java
@@ -1,0 +1,72 @@
+package dev.codesupport.web.common.configuration;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+
+/**
+ * Authentication Implementation used for authorizations
+ * <p>Authenticates the provided authentication credentials with Firebase</p>
+ */
+@Component
+public class FirebaseAuthenticationProvider implements AuthenticationProvider {
+
+    /**
+     * Boilerplate, determines what authentication types this provider supports.
+     *
+     * @param authentication Authentication class type
+     * @return True if the AuthenticationProvider supports it, False otherwise
+     */
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return authentication.equals(UsernamePasswordAuthenticationToken.class);
+    }
+
+    /**
+     * Authenticates the given authentication credentials
+     *
+     * @param authentication Authentication details to authenticate
+     * @return New authentication token if successful, null otherwise
+     */
+    @Override
+    public Authentication authenticate(Authentication authentication) {
+
+        String username = authentication.getName();
+        String password = authentication.getCredentials().toString();
+
+        UsernamePasswordAuthenticationToken authenticationToken;
+
+        if (shouldAuthenticateAgainstThirdPartySystem(username, password)) {
+
+            // use the credentials
+            // and authenticate against the third-party system
+            authenticationToken = new UsernamePasswordAuthenticationToken(
+                    username,
+                    password,
+                    new ArrayList<>()
+            );
+        } else {
+            authenticationToken = null;
+        }
+
+        return authenticationToken;
+    }
+
+    /**
+     * Authenticates the given credentials with Firebase
+     * Stubbed for now.
+     *
+     * @param username Username for credentials.
+     * @param password Password for credentials.
+     * @return True if credentials are authenticated with Firebase, False otherwise.
+     */
+    boolean shouldAuthenticateAgainstThirdPartySystem(String username, String password) {
+        //TODO: Federate authentication with Firebase.
+        //Stubbed for now.
+        return username.equalsIgnoreCase("admin") && password.equalsIgnoreCase("admin");
+    }
+
+}

--- a/src/main/java/dev/codesupport/web/common/configuration/SimpleAuthenticationEntryPoint.java
+++ b/src/main/java/dev/codesupport/web/common/configuration/SimpleAuthenticationEntryPoint.java
@@ -1,0 +1,25 @@
+package dev.codesupport.web.common.configuration;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+/**
+ * Overrides response of unauthorized requests, sending back 401 status
+ */
+@Component
+public class SimpleAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    /**
+     * Implements modifications of request/response for authentications
+     */
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+    }
+}

--- a/src/main/java/dev/codesupport/web/common/configuration/WebSecurityConfig.java
+++ b/src/main/java/dev/codesupport/web/common/configuration/WebSecurityConfig.java
@@ -1,0 +1,104 @@
+package dev.codesupport.web.common.configuration;
+
+import dev.codesupport.web.common.security.JwtRequestFilter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+/**
+ * Configures security options
+ * <p>Sets up security configurations including:
+ * Password Encryption Type,
+ * Authentication Provider,
+ * Request Filters</p>
+ */
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(jsr250Enabled = true)//(prePostEnabled = true, proxyTargetClass = true)
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private SimpleAuthenticationEntryPoint simpleAuthenticationEntryPoint;
+    private UserDetailsService userDetailsService;
+    private JwtRequestFilter jwtRequestFilter;
+    private AuthenticationProvider authenticationProvider;
+
+    @Autowired
+    public WebSecurityConfig(
+            SimpleAuthenticationEntryPoint simpleAuthenticationEntryPoint,
+            UserDetailsService userDetailsService,
+            JwtRequestFilter jwtRequestFilter,
+            AuthenticationProvider authenticationProvider
+    ) {
+        this.simpleAuthenticationEntryPoint = simpleAuthenticationEntryPoint;
+        this.userDetailsService = userDetailsService;
+        this.jwtRequestFilter = jwtRequestFilter;
+        this.authenticationProvider = authenticationProvider;
+    }
+
+    /**
+     * @return The type of password encryption to use
+     */
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    /**
+     * Returns the configured authentication manager
+     *
+     * @return The configured AuthenticationManager
+     * @throws Exception Thrown by framework
+     */
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean(); // Default configuration
+    }
+
+    /**
+     * Configure the AuthenticationManagerBuilder
+     * <p>Configures the AuthenticationManagerBuilder to be used.</p>
+     *
+     * @param auth AuthenticationManagerBuilder to configure
+     * @throws Exception Thrown by framework
+     */
+    @Autowired
+    @Override
+    public void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth
+                .authenticationProvider(authenticationProvider) // Configure authentication Provider to use
+                .userDetailsService(userDetailsService) // Configure UserDetailService to use
+                .passwordEncoder(passwordEncoder()); // Configure encoder to use
+    }
+
+    /**
+     * Configure HttpSecurity
+     * <p>Sets up configurations for the HttpSecurity such as CSRF and authentication.</p>
+     *
+     * @param httpSecurity The HttpSecurity to configure
+     * @throws Exception Thrown by framework
+     */
+    @Override
+    protected void configure(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.csrf().disable() //CSRF disabled for now
+                // Set entry point for authentication, this seems to only fire on auth failures?
+                .exceptionHandling().authenticationEntryPoint(simpleAuthenticationEntryPoint).and()
+                // Set up for stateless
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+        // Add JWT filter to apply to incoming requests.
+        httpSecurity.addFilterBefore(jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/dev/codesupport/web/common/exception/InvalidUserException.java
+++ b/src/main/java/dev/codesupport/web/common/exception/InvalidUserException.java
@@ -1,0 +1,7 @@
+package dev.codesupport.web.common.exception;
+
+public class InvalidUserException extends RuntimeException {
+    public InvalidUserException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+}

--- a/src/main/java/dev/codesupport/web/common/exception/ServiceLayerException.java
+++ b/src/main/java/dev/codesupport/web/common/exception/ServiceLayerException.java
@@ -26,4 +26,8 @@ public class ServiceLayerException extends RuntimeException {
     public ServiceLayerException(Reason reason) {
         super(reason.toString());
     }
+
+    public ServiceLayerException(Reason reason, Throwable throwable) {
+        super(reason.toString(), throwable);
+    }
 }

--- a/src/main/java/dev/codesupport/web/common/security/AuthenticationRequest.java
+++ b/src/main/java/dev/codesupport/web/common/security/AuthenticationRequest.java
@@ -1,0 +1,20 @@
+package dev.codesupport.web.common.security;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * Model for incoming authorization requests.
+ */
+@Data
+@NoArgsConstructor
+public class AuthenticationRequest implements Serializable {
+
+    private static final long serialVersionUID = 4690455532399413757L;
+
+    private String username;
+    private String password;
+
+}

--- a/src/main/java/dev/codesupport/web/common/security/JwtRequestFilter.java
+++ b/src/main/java/dev/codesupport/web/common/security/JwtRequestFilter.java
@@ -1,0 +1,109 @@
+package dev.codesupport.web.common.security;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import dev.codesupport.web.common.service.service.AuthenticationUserDetailsService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Intercepts all incoming requests, checking for and validating any present JWT
+ */
+@Component
+@Slf4j
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+    private AuthenticationUserDetailsService userDetailsService;
+
+    @Autowired
+    public JwtRequestFilter(AuthenticationUserDetailsService userDetailsService) {
+        this.userDetailsService = userDetailsService;
+    }
+
+    /**
+     * Executes the implemented process for the request.
+     * This is called automatically by the framework.
+     *
+     * @param request  The associated request
+     * @param response The associated response
+     * @param chain    The filter chain
+     * @throws ServletException Thrown by framework
+     * @throws IOException Thrown by framework
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        // Configure the spring security context
+        configureSpringSecurityContext(request);
+
+        // Boilerplate call, invokes subsequent filter layers
+        chain.doFilter(request, response);
+    }
+
+    /**
+     * Configures the Spring security context for the request
+     *
+     * @param request The corresponding request
+     */
+    void configureSpringSecurityContext(HttpServletRequest request) {
+        // Get token from request
+        String jwtToken = getTokenFromRequest(request);
+
+        if (jwtToken != null) {
+            //TODO: Get username from token, this is a stub.
+            String username = "admin"; // stub
+
+            // If username found and authentication is not already configured
+            if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                // Get user's details
+                UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+
+                //TODO: Validate token correctly, this is a stub.
+                if (jwtToken.equalsIgnoreCase("1234")) { // Stub
+                    // Configure the authentication so it can be used later by the framework for access checks.
+                    UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities());
+                    usernamePasswordAuthenticationToken
+                            .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                    SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+                }
+            }
+        }
+    }
+
+    /**
+     * Extract token from header.
+     *
+     * @param request Corresponding request to extract token from
+     * @return The raw token ascii string
+     */
+    String getTokenFromRequest(HttpServletRequest request) {
+        final String requestTokenHeader = request.getHeader("Authorization");
+        String jwtToken;
+
+        // Get the token from the header
+        if (StringUtils.startsWith(requestTokenHeader, "Bearer ")) {
+            jwtToken = requestTokenHeader.substring(7); //Removes "Bearer " prefix
+        } else { // Invalid authorization header
+            jwtToken = null;
+            if (log.isDebugEnabled()) {
+                logger.debug("JWT Token does not begin with Bearer String");
+            }
+        }
+
+        return jwtToken;
+    }
+}

--- a/src/main/java/dev/codesupport/web/common/service/controller/AuthenticationController.java
+++ b/src/main/java/dev/codesupport/web/common/service/controller/AuthenticationController.java
@@ -1,0 +1,64 @@
+package dev.codesupport.web.common.service.controller;
+
+import dev.codesupport.web.common.exception.InvalidUserException;
+import dev.codesupport.web.common.security.AuthenticationRequest;
+import dev.codesupport.web.common.service.service.AuthenticationUserDetailsService;
+import dev.codesupport.web.common.service.service.RestResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Accepts post requests containing username/password credentials
+ * to then be validated, resulting in returned JWT if found valid.
+ */
+@RestController
+public class AuthenticationController {
+
+    private AuthenticationManager authenticationManager;
+    private AuthenticationUserDetailsService userDetailsService;
+
+    @Autowired
+    public AuthenticationController(
+            AuthenticationManager authenticationManager,
+            AuthenticationUserDetailsService userDetailsService
+    ) {
+        this.authenticationManager = authenticationManager;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @PostMapping(value = "/authenticate")
+    public ResponseEntity<RestResponse<Serializable>> createAuthenticationToken(@RequestBody AuthenticationRequest authenticationRequest) {
+        authenticate(authenticationRequest.getUsername(), authenticationRequest.getPassword());
+        final UserDetails userDetails = userDetailsService
+                .loadUserByUsername(authenticationRequest.getUsername());
+        //TODO: Create token with user details.
+        final String token = "1234";
+        return ResponseEntity.ok(
+                getRestResponse(Collections.singletonList(token))
+        );
+    }
+
+    RestResponse<Serializable> getRestResponse(List<Serializable> objectList) {
+        return new RestResponse<>(objectList);
+    }
+
+    void authenticate(String username, String password) {
+        try {
+            // Authenticate, if no exceptions thrown then we are good.
+            authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(username, password));
+        } catch (DisabledException e) {
+            throw new InvalidUserException("Account is disabled.", e);
+        }
+    }
+}

--- a/src/main/java/dev/codesupport/web/common/service/controller/throwparser/parser/AccessDeniedExceptionParser.java
+++ b/src/main/java/dev/codesupport/web/common/service/controller/throwparser/parser/AccessDeniedExceptionParser.java
@@ -1,0 +1,33 @@
+package dev.codesupport.web.common.service.controller.throwparser.parser;
+
+import dev.codesupport.web.common.service.controller.throwparser.AbstractThrowableParser;
+import dev.codesupport.web.common.service.service.RestStatus;
+import lombok.NoArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+
+/**
+ * Used to parse Spring's {@link AccessDeniedException} type throwables.
+ *
+ * @see AccessDeniedException
+ * @see AbstractThrowableParser
+ */
+@Component
+@NoArgsConstructor
+class AccessDeniedExceptionParser extends AbstractThrowableParser<AccessDeniedException> {
+
+    @Override
+    protected AbstractThrowableParser<AccessDeniedException> instantiate() {
+        return new AccessDeniedExceptionParser();
+    }
+
+    @Override
+    protected String responseMessage() {
+        return "You are not permitted to perform the requested action on the requested resource.";
+    }
+
+    @Override
+    protected RestStatus responseStatus() {
+        return RestStatus.UNAUTHORIZED;
+    }
+}

--- a/src/main/java/dev/codesupport/web/common/service/controller/throwparser/parser/BadCredentialsExceptionParser.java
+++ b/src/main/java/dev/codesupport/web/common/service/controller/throwparser/parser/BadCredentialsExceptionParser.java
@@ -1,0 +1,33 @@
+package dev.codesupport.web.common.service.controller.throwparser.parser;
+
+import dev.codesupport.web.common.service.controller.throwparser.AbstractThrowableParser;
+import dev.codesupport.web.common.service.service.RestStatus;
+import lombok.NoArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.stereotype.Component;
+
+/**
+ * Used to parse Spring's {@link BadCredentialsException} type throwables.
+ *
+ * @see BadCredentialsException
+ * @see AbstractThrowableParser
+ */
+@Component
+@NoArgsConstructor
+class BadCredentialsExceptionParser extends AbstractThrowableParser<BadCredentialsException> {
+
+    @Override
+    protected AbstractThrowableParser<BadCredentialsException> instantiate() {
+        return new BadCredentialsExceptionParser();
+    }
+
+    @Override
+    protected String responseMessage() {
+        return "The username/password supplied was invalid/inactive";
+    }
+
+    @Override
+    protected RestStatus responseStatus() {
+        return RestStatus.UNAUTHORIZED;
+    }
+}

--- a/src/main/java/dev/codesupport/web/common/service/controller/throwparser/parser/HttpMediaTypeNotSupportedExceptionParser.java
+++ b/src/main/java/dev/codesupport/web/common/service/controller/throwparser/parser/HttpMediaTypeNotSupportedExceptionParser.java
@@ -1,0 +1,30 @@
+package dev.codesupport.web.common.service.controller.throwparser.parser;
+
+import dev.codesupport.web.common.service.controller.throwparser.AbstractThrowableParser;
+import lombok.NoArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+
+/**
+ * Used to parse Spring's {@link HttpMediaTypeNotSupportedException} type throwables.
+ *
+ * @see HttpMediaTypeNotSupportedException
+ * @see AbstractThrowableParser
+ */
+@Component
+@NoArgsConstructor
+class HttpMediaTypeNotSupportedExceptionParser extends AbstractThrowableParser<HttpMediaTypeNotSupportedException> {
+
+    @Override
+    protected AbstractThrowableParser<HttpMediaTypeNotSupportedException> instantiate() {
+        return new HttpMediaTypeNotSupportedExceptionParser();
+    }
+
+    @Override
+    protected String responseMessage() {
+        MediaType contentType = throwable.getContentType();
+        String message = (contentType != null) ? contentType.getType() + "/" + contentType.getSubtype() : "";
+        return "Content type not supported: " + message;
+    }
+}

--- a/src/main/java/dev/codesupport/web/common/service/controller/throwparser/parser/InvalidUserExceptionParser.java
+++ b/src/main/java/dev/codesupport/web/common/service/controller/throwparser/parser/InvalidUserExceptionParser.java
@@ -1,0 +1,28 @@
+package dev.codesupport.web.common.service.controller.throwparser.parser;
+
+import dev.codesupport.web.common.exception.InvalidUserException;
+import dev.codesupport.web.common.service.controller.throwparser.AbstractThrowableParser;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Used to parse Spring's {@link InvalidUserException} type throwables.
+ *
+ * @see InvalidUserException
+ * @see AbstractThrowableParser
+ */
+@Component
+@NoArgsConstructor
+class InvalidUserExceptionParser extends AbstractThrowableParser<InvalidUserException> {
+
+    @Override
+    protected AbstractThrowableParser<InvalidUserException> instantiate() {
+        return new InvalidUserExceptionParser();
+    }
+
+    @Override
+    protected String responseMessage() {
+        return throwable.getMessage();
+    }
+
+}

--- a/src/main/java/dev/codesupport/web/common/service/service/AuthenticationUserDetailsService.java
+++ b/src/main/java/dev/codesupport/web/common/service/service/AuthenticationUserDetailsService.java
@@ -1,0 +1,71 @@
+package dev.codesupport.web.common.service.service;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Gathers information for UserDetails of authenticating user.
+ */
+@Service
+public class AuthenticationUserDetailsService implements UserDetailsService {
+
+    /**
+     * Gets details of user to authenticate
+     * This is stubbed out for now.
+     *
+     * @param username The username associated with the requested user details
+     * @return The UserDetails object populated with desired info.
+     */
+    @Override
+    public UserDetails loadUserByUsername(String username) {
+        //TODO: Remove stub, add true implementation, getting details from persistent storage.
+        return new UserDetails() {
+            private static final long serialVersionUID = 2139825498003613413L;
+
+            @Override
+            public Collection<? extends GrantedAuthority> getAuthorities() {
+                return Arrays.asList(
+                        new SimpleGrantedAuthority("ROLE_MEMBER"),
+                        new SimpleGrantedAuthority("ROLE_ADMIN")
+                );
+            }
+
+            @Override
+            public String getPassword() {
+                return "admin";
+            }
+
+            @Override
+            public String getUsername() {
+                return "admin";
+            }
+
+            @Override
+            public boolean isAccountNonExpired() {
+                return true;
+            }
+
+            @Override
+            public boolean isAccountNonLocked() {
+                return true;
+            }
+
+            @Override
+            public boolean isCredentialsNonExpired() {
+                return true;
+            }
+
+            @Override
+            public boolean isEnabled() {
+                return true;
+            }
+        };
+    }
+
+}

--- a/src/test/java/dev/codesupport/web/common/configuration/FirebaseAuthenticationProviderTest.java
+++ b/src/test/java/dev/codesupport/web/common/configuration/FirebaseAuthenticationProviderTest.java
@@ -1,0 +1,95 @@
+package dev.codesupport.web.common.configuration;
+
+import org.junit.Test;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+public class FirebaseAuthenticationProviderTest {
+
+    @Test
+    public void shouldReturnTrueForSupportsUsernamePasswordAuthenticationToken() {
+        FirebaseAuthenticationProvider authenticationProvider = new FirebaseAuthenticationProvider();
+
+        assertTrue(
+                authenticationProvider.supports(UsernamePasswordAuthenticationToken.class)
+        );
+    }
+
+    @Test
+    public void shouldReturnFalseForSupportsNonUsernamePasswordAuthenticationToken() {
+        FirebaseAuthenticationProvider authenticationProvider = new FirebaseAuthenticationProvider();
+
+        assertFalse(
+                authenticationProvider.supports(AbstractAuthenticationToken.class)
+        );
+    }
+
+    @Test
+    public void shouldReturnNullForAuthenticatingInvalidAuthCredentials() {
+        FirebaseAuthenticationProvider authenticationProviderSpy = spy(FirebaseAuthenticationProvider.class);
+
+        Authentication mockAuthentication = mock(Authentication.class);
+
+        String username = "testuser";
+        Object password = "password123";
+
+        doReturn(username)
+                .when(mockAuthentication)
+                .getName();
+
+        doReturn(password)
+                .when(mockAuthentication)
+                .getCredentials();
+
+        doReturn(false)
+                .when(authenticationProviderSpy)
+                .shouldAuthenticateAgainstThirdPartySystem(username, password.toString());
+
+        assertNull(
+                authenticationProviderSpy.authenticate(mockAuthentication)
+        );
+    }
+
+    @Test
+    public void shouldReturnAuthenticationForAuthenticatingValidAuthCredentials() {
+        FirebaseAuthenticationProvider authenticationProviderSpy = spy(FirebaseAuthenticationProvider.class);
+
+        Authentication mockAuthentication = mock(Authentication.class);
+
+        String username = "testuser";
+        Object password = "password123";
+
+        doReturn(username)
+                .when(mockAuthentication)
+                .getName();
+
+        doReturn(password)
+                .when(mockAuthentication)
+                .getCredentials();
+
+        doReturn(true)
+                .when(authenticationProviderSpy)
+                .shouldAuthenticateAgainstThirdPartySystem(username, password.toString());
+
+        Authentication expected = new UsernamePasswordAuthenticationToken(
+                username,
+                password,
+                new ArrayList<>()
+        );
+        Authentication actual = authenticationProviderSpy.authenticate(mockAuthentication);
+
+        assertEquals(expected, actual);
+    }
+
+}

--- a/src/test/java/dev/codesupport/web/common/configuration/SimpleAuthenticationEntryPointTest.java
+++ b/src/test/java/dev/codesupport/web/common/configuration/SimpleAuthenticationEntryPointTest.java
@@ -1,0 +1,35 @@
+package dev.codesupport.web.common.configuration;
+
+import org.junit.Test;
+import org.springframework.security.core.AuthenticationException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class SimpleAuthenticationEntryPointTest {
+
+    @Test
+    public void shouldHaveSentCorrectErrorInResponse() throws IOException {
+        HttpServletRequest mockHttpServletRequest = mock(HttpServletRequest.class);
+        HttpServletResponse mockHttpServletResponse = mock(HttpServletResponse.class);
+        AuthenticationException mockAuthenticationException = mock(AuthenticationException.class);
+
+        SimpleAuthenticationEntryPoint entryPoint = new SimpleAuthenticationEntryPoint();
+
+        doNothing()
+                .when(mockHttpServletResponse)
+                .sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+
+        entryPoint.commence(mockHttpServletRequest, mockHttpServletResponse, mockAuthenticationException);
+
+        verify(mockHttpServletResponse, times(1))
+                .sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+    }
+}

--- a/src/test/java/dev/codesupport/web/common/configuration/WebSecurityConfigTest.java
+++ b/src/test/java/dev/codesupport/web/common/configuration/WebSecurityConfigTest.java
@@ -1,0 +1,57 @@
+package dev.codesupport.web.common.configuration;
+
+import dev.codesupport.web.common.security.JwtRequestFilter;
+import org.junit.Test;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+public class WebSecurityConfigTest {
+
+    @Test
+    public void shouldReturnBCryptPasswordEncoderForPasswordEncoder() {
+        SimpleAuthenticationEntryPoint mockSimpleAuthenticationEntryPoint = mock(SimpleAuthenticationEntryPoint.class);
+        UserDetailsService mockUserDetailsService = mock(UserDetailsService.class);
+        JwtRequestFilter mockJwtRequestFilter = mock(JwtRequestFilter.class);
+        AuthenticationProvider mockAuthenticationProvider = mock(AuthenticationProvider.class);
+
+        WebSecurityConfig webSecurityConfigSpy = spy(
+                new WebSecurityConfig(
+                        mockSimpleAuthenticationEntryPoint,
+                        mockUserDetailsService,
+                        mockJwtRequestFilter,
+                        mockAuthenticationProvider
+                )
+        );
+
+        assertTrue(webSecurityConfigSpy.passwordEncoder() instanceof BCryptPasswordEncoder);
+    }
+
+    @Test
+    public void shouldReturnNewInstanceOfEncoder() {
+        SimpleAuthenticationEntryPoint mockSimpleAuthenticationEntryPoint = mock(SimpleAuthenticationEntryPoint.class);
+        UserDetailsService mockUserDetailsService = mock(UserDetailsService.class);
+        JwtRequestFilter mockJwtRequestFilter = mock(JwtRequestFilter.class);
+        AuthenticationProvider mockAuthenticationProvider = mock(AuthenticationProvider.class);
+
+        WebSecurityConfig webSecurityConfigSpy = spy(
+                new WebSecurityConfig(
+                        mockSimpleAuthenticationEntryPoint,
+                        mockUserDetailsService,
+                        mockJwtRequestFilter,
+                        mockAuthenticationProvider
+                )
+        );
+
+        PasswordEncoder firstInstance = webSecurityConfigSpy.passwordEncoder();
+        PasswordEncoder secondInstance = webSecurityConfigSpy.passwordEncoder();
+
+        assertNotSame(firstInstance, secondInstance);
+    }
+}

--- a/src/test/java/dev/codesupport/web/common/security/JwtRequestFilterTest.java
+++ b/src/test/java/dev/codesupport/web/common/security/JwtRequestFilterTest.java
@@ -1,0 +1,183 @@
+package dev.codesupport.web.common.security;
+
+import dev.codesupport.web.common.service.service.AuthenticationUserDetailsService;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class JwtRequestFilterTest {
+
+    @Before
+    public void setup() {
+        SecurityContextHolder.getContext().setAuthentication(null);
+    }
+
+    @Test
+    public void shouldInvokeConfigureSpringSecurityContext() throws IOException, ServletException {
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+        FilterChain mockFilterChain = mock(FilterChain.class);
+        AuthenticationUserDetailsService mockUserDetailsService = mock(AuthenticationUserDetailsService.class);
+
+        JwtRequestFilter jwtRequestFilterSpy = spy(new JwtRequestFilter(mockUserDetailsService));
+
+        doNothing()
+                .when(jwtRequestFilterSpy)
+                .configureSpringSecurityContext(mockRequest);
+
+        doNothing()
+                .when(mockFilterChain)
+                .doFilter(mockRequest, mockResponse);
+
+        jwtRequestFilterSpy.doFilterInternal(mockRequest, mockResponse, mockFilterChain);
+
+        verify(jwtRequestFilterSpy, times(1))
+                .configureSpringSecurityContext(mockRequest);
+    }
+
+    @Test
+    public void shouldInvokeFilterChainDoFilter() throws IOException, ServletException {
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        HttpServletResponse mockResponse = mock(HttpServletResponse.class);
+        FilterChain mockFilterChain = mock(FilterChain.class);
+        AuthenticationUserDetailsService mockUserDetailsService = mock(AuthenticationUserDetailsService.class);
+
+        JwtRequestFilter jwtRequestFilterSpy = spy(new JwtRequestFilter(mockUserDetailsService));
+
+        doNothing()
+                .when(jwtRequestFilterSpy)
+                .configureSpringSecurityContext(mockRequest);
+
+        doNothing()
+                .when(mockFilterChain)
+                .doFilter(mockRequest, mockResponse);
+
+        jwtRequestFilterSpy.doFilterInternal(mockRequest, mockResponse, mockFilterChain);
+
+        verify(mockFilterChain, times(1))
+                .doFilter(mockRequest, mockResponse);
+    }
+
+    @Test
+    public void shouldConfigureSpringSecurityContextWithNoAutheticationIfTokenNull() {
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        AuthenticationUserDetailsService mockUserDetailsService = mock(AuthenticationUserDetailsService.class);
+
+        JwtRequestFilter jwtRequestFilterSpy = spy(new JwtRequestFilter(mockUserDetailsService));
+
+        doReturn(null)
+                .when(jwtRequestFilterSpy)
+                .getTokenFromRequest(mockRequest);
+
+        jwtRequestFilterSpy.configureSpringSecurityContext(mockRequest);
+
+        Authentication actual = SecurityContextHolder.getContext().getAuthentication();
+
+        assertNull(actual);
+    }
+
+    @Test
+    public void shouldConfigureSpringSecurityContextWithCorrectAutheticationIfTokenValid() {
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        AuthenticationUserDetailsService mockUserDetailsService = mock(AuthenticationUserDetailsService.class);
+        UserDetails mockUserDetails = mock(UserDetails.class);
+
+        doReturn(mockUserDetails)
+                .when(mockUserDetailsService)
+                .loadUserByUsername("admin");
+
+        JwtRequestFilter jwtRequestFilterSpy = spy(new JwtRequestFilter(mockUserDetailsService));
+
+        doReturn("1234")
+                .when(jwtRequestFilterSpy)
+                .getTokenFromRequest(mockRequest);
+
+        jwtRequestFilterSpy.configureSpringSecurityContext(mockRequest);
+
+        UsernamePasswordAuthenticationToken expected = new UsernamePasswordAuthenticationToken(
+                mockUserDetails, null, mockUserDetails.getAuthorities());
+        expected
+                .setDetails(new WebAuthenticationDetailsSource().buildDetails(mockRequest));
+
+        Authentication actual = SecurityContextHolder.getContext().getAuthentication();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldReturnNullIfTokenNotSet() {
+        String headerName = "Authorization";
+
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        AuthenticationUserDetailsService mockUserDetailsService = mock(AuthenticationUserDetailsService.class);
+
+        JwtRequestFilter jwtRequestFilterSpy = spy(new JwtRequestFilter(mockUserDetailsService));
+
+        doReturn(null)
+                .when(mockRequest)
+                .getHeader(headerName);
+
+        String actual = jwtRequestFilterSpy.getTokenFromRequest(mockRequest);
+
+        assertNull(actual);
+    }
+
+    @Test
+    public void shouldReturnNullIfTokenInvalid() {
+        String headerName = "Authorization";
+        String headerValue = "Basic 1234";
+
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        AuthenticationUserDetailsService mockUserDetailsService = mock(AuthenticationUserDetailsService.class);
+
+        JwtRequestFilter jwtRequestFilterSpy = spy(new JwtRequestFilter(mockUserDetailsService));
+
+        doReturn(headerValue)
+                .when(mockRequest)
+                .getHeader(headerName);
+
+        String actual = jwtRequestFilterSpy.getTokenFromRequest(mockRequest);
+
+        assertNull(actual);
+    }
+
+    @Test
+    public void shouldReturnCorrectTokenIfTokenValid() {
+        String expected = "1234";
+        String headerName = "Authorization";
+        String headerValue = "Bearer " + expected;
+
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        AuthenticationUserDetailsService mockUserDetailsService = mock(AuthenticationUserDetailsService.class);
+
+        JwtRequestFilter jwtRequestFilterSpy = spy(new JwtRequestFilter(mockUserDetailsService));
+
+        doReturn(headerValue)
+                .when(mockRequest)
+                .getHeader(headerName);
+
+        String actual = jwtRequestFilterSpy.getTokenFromRequest(mockRequest);
+
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/dev/codesupport/web/common/service/controller/AuthenticationControllerTest.java
+++ b/src/test/java/dev/codesupport/web/common/service/controller/AuthenticationControllerTest.java
@@ -1,0 +1,169 @@
+package dev.codesupport.web.common.service.controller;
+
+import dev.codesupport.web.common.exception.InvalidUserException;
+import dev.codesupport.web.common.security.AuthenticationRequest;
+import dev.codesupport.web.common.service.service.AuthenticationUserDetailsService;
+import dev.codesupport.web.common.service.service.RestResponse;
+import org.junit.Test;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+//DefaultAnnotationParam - If not annotated, Sonar complains there is no assertion made, would rather be explicit
+@SuppressWarnings("DefaultAnnotationParam")
+public class AuthenticationControllerTest {
+
+    @Test
+    public void shouldReturnTokenIfAuthenticUser() {
+        AuthenticationManager mockAuthenticationManager = mock(AuthenticationManager.class);
+
+        AuthenticationUserDetailsService mockAuthenticationUserDetailsService = mock(AuthenticationUserDetailsService.class);
+
+        AuthenticationController controllerSpy = spy(new AuthenticationController(mockAuthenticationManager, mockAuthenticationUserDetailsService));
+
+        AuthenticationRequest mockAuthenticationRequest = mock(AuthenticationRequest.class);
+
+        String referenceId = "12345";
+        String username = "testuser";
+        String password = "password123";
+
+        List<Serializable> token = Collections.singletonList("1234");
+
+        RestResponse<Serializable> restResponse = new RestResponse<>(token);
+        restResponse.setReferenceId(referenceId);
+
+        doReturn(restResponse)
+                .when(controllerSpy)
+                .getRestResponse(token);
+
+        //ResultOfMethodCallIgnored - Not using results, we're creating mocks
+        //noinspection ResultOfMethodCallIgnored
+        doReturn(username)
+                .when(mockAuthenticationRequest)
+                .getUsername();
+
+        //ResultOfMethodCallIgnored - Not using results, we're creating mocks
+        //noinspection ResultOfMethodCallIgnored
+        doReturn(password)
+                .when(mockAuthenticationRequest)
+                .getPassword();
+
+        doNothing()
+                .when(controllerSpy)
+                .authenticate(username, password);
+
+        RestResponse<Serializable> expectedResponse = new RestResponse<>(token);
+        expectedResponse.setReferenceId(referenceId);
+
+        ResponseEntity<RestResponse<Serializable>> expected = ResponseEntity.ok(expectedResponse);
+        ResponseEntity<RestResponse<Serializable>> actual = controllerSpy.createAuthenticationToken(mockAuthenticationRequest);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldReturnCorrectRestResponseInstance() {
+        AuthenticationManager mockAuthenticationManager = mock(AuthenticationManager.class);
+
+        AuthenticationUserDetailsService mockAuthenticationUserDetailsService = mock(AuthenticationUserDetailsService.class);
+
+        AuthenticationController controller = new AuthenticationController(mockAuthenticationManager, mockAuthenticationUserDetailsService);
+
+        List<Serializable> expected = Collections.singletonList("string");
+
+        List<Serializable> actual = controller.getRestResponse(expected).getResponse();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldReturnNewRestResponseInstance() {
+        AuthenticationManager mockAuthenticationManager = mock(AuthenticationManager.class);
+
+        AuthenticationUserDetailsService mockAuthenticationUserDetailsService = mock(AuthenticationUserDetailsService.class);
+
+        AuthenticationController controller = new AuthenticationController(mockAuthenticationManager, mockAuthenticationUserDetailsService);
+
+        List<Serializable> strings = Collections.singletonList("string");
+
+        RestResponse<Serializable> firstInstance = controller.getRestResponse(strings);
+        RestResponse<Serializable> secondInstance = controller.getRestResponse(strings);
+
+        assertNotSame(firstInstance, secondInstance);
+    }
+
+    @Test(expected = InvalidUserException.class)
+    public void shouldThrowInvalidUserExceptionOnDisabledExceptions() {
+        AuthenticationManager mockAuthenticationManager = mock(AuthenticationManager.class);
+
+        AuthenticationUserDetailsService mockAuthenticationUserDetailsService = mock(AuthenticationUserDetailsService.class);
+
+        AuthenticationController controller = new AuthenticationController(mockAuthenticationManager, mockAuthenticationUserDetailsService);
+
+        String username = "testuser";
+        String password = "password123";
+
+        doThrow(DisabledException.class)
+                .when(mockAuthenticationManager)
+                .authenticate(
+                        new UsernamePasswordAuthenticationToken(username, password)
+                );
+
+        controller.authenticate(username, password);
+    }
+
+    @Test(expected = BadCredentialsException.class)
+    public void shouldBubbleBadCredentialExceptions() {
+        AuthenticationManager mockAuthenticationManager = mock(AuthenticationManager.class);
+
+        AuthenticationUserDetailsService mockAuthenticationUserDetailsService = mock(AuthenticationUserDetailsService.class);
+
+        AuthenticationController controller = new AuthenticationController(mockAuthenticationManager, mockAuthenticationUserDetailsService);
+
+        String username = "testuser";
+        String password = "password123";
+
+        doThrow(BadCredentialsException.class)
+                .when(mockAuthenticationManager)
+                .authenticate(
+                        new UsernamePasswordAuthenticationToken(username, password)
+                );
+
+        controller.authenticate(username, password);
+    }
+
+    @Test(expected = Test.None.class)
+    public void shouldThrowNoExceptionsIfValidAuthentication() {
+        AuthenticationManager mockAuthenticationManager = mock(AuthenticationManager.class);
+
+        AuthenticationUserDetailsService mockAuthenticationUserDetailsService = mock(AuthenticationUserDetailsService.class);
+
+        AuthenticationController controller = new AuthenticationController(mockAuthenticationManager, mockAuthenticationUserDetailsService);
+
+        String username = "testuser";
+        String password = "password123";
+
+        doReturn(null)
+                .when(mockAuthenticationManager)
+                .authenticate(
+                        new UsernamePasswordAuthenticationToken(username, password)
+                );
+
+        controller.authenticate(username, password);
+    }
+
+}

--- a/src/test/java/dev/codesupport/web/common/service/controller/throwparser/parser/AccessDeniedExceptionParserTest.java
+++ b/src/test/java/dev/codesupport/web/common/service/controller/throwparser/parser/AccessDeniedExceptionParserTest.java
@@ -1,0 +1,58 @@
+package dev.codesupport.web.common.service.controller.throwparser.parser;
+
+import dev.codesupport.web.common.service.controller.throwparser.AbstractThrowableParser;
+import dev.codesupport.web.common.service.service.RestStatus;
+import org.junit.Test;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class AccessDeniedExceptionParserTest {
+
+    @Test
+    public void shouldReturnCorrectParserType() {
+        AccessDeniedExceptionParser parser = new AccessDeniedExceptionParser();
+
+        AbstractThrowableParser<AccessDeniedException> instancedParser = parser.instantiate();
+
+        assertTrue(instancedParser instanceof AccessDeniedExceptionParser);
+    }
+
+    @Test
+    public void shouldCreateNewInstance() {
+        AccessDeniedExceptionParser parser = new AccessDeniedExceptionParser();
+
+        AbstractThrowableParser<AccessDeniedException> firstInstance = parser.instantiate();
+        AbstractThrowableParser<AccessDeniedException> secondInstance = parser.instantiate();
+
+        assertNotSame(firstInstance, secondInstance);
+    }
+
+    @Test
+    public void shouldReturnCorrectMessage() {
+        AccessDeniedExceptionParser parser = new AccessDeniedExceptionParser();
+
+        AccessDeniedException mockException = mock(AccessDeniedException.class);
+
+        ReflectionTestUtils.setField(parser, "throwable", mockException);
+
+        String exceptionMessage = "You are not permitted to perform the requested action on the requested resource.";
+        String actual = parser.responseMessage();
+
+        assertEquals(exceptionMessage, actual);
+    }
+
+    @Test
+    public void shouldReturnCorrectStatus() {
+        AccessDeniedExceptionParser parser = new AccessDeniedExceptionParser();
+
+        RestStatus expected = RestStatus.UNAUTHORIZED;
+        RestStatus actual = ReflectionTestUtils.invokeMethod(parser, "responseStatus");
+
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/dev/codesupport/web/common/service/controller/throwparser/parser/BadCredentialsExceptionParserTest.java
+++ b/src/test/java/dev/codesupport/web/common/service/controller/throwparser/parser/BadCredentialsExceptionParserTest.java
@@ -1,0 +1,58 @@
+package dev.codesupport.web.common.service.controller.throwparser.parser;
+
+import dev.codesupport.web.common.service.controller.throwparser.AbstractThrowableParser;
+import dev.codesupport.web.common.service.service.RestStatus;
+import org.junit.Test;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class BadCredentialsExceptionParserTest {
+
+    @Test
+    public void shouldReturnCorrectParserType() {
+        BadCredentialsExceptionParser parser = new BadCredentialsExceptionParser();
+
+        AbstractThrowableParser<BadCredentialsException> instancedParser = parser.instantiate();
+
+        assertTrue(instancedParser instanceof BadCredentialsExceptionParser);
+    }
+
+    @Test
+    public void shouldCreateNewInstance() {
+        BadCredentialsExceptionParser parser = new BadCredentialsExceptionParser();
+
+        AbstractThrowableParser<BadCredentialsException> firstInstance = parser.instantiate();
+        AbstractThrowableParser<BadCredentialsException> secondInstance = parser.instantiate();
+
+        assertNotSame(firstInstance, secondInstance);
+    }
+
+    @Test
+    public void shouldReturnCorrectMessage() {
+        BadCredentialsExceptionParser parser = new BadCredentialsExceptionParser();
+
+        BadCredentialsException mockException = mock(BadCredentialsException.class);
+
+        ReflectionTestUtils.setField(parser, "throwable", mockException);
+
+        String expected = "The username/password supplied was invalid/inactive";
+        String actual = parser.responseMessage();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldReturnCorrectStatus() {
+        BadCredentialsExceptionParser parser = new BadCredentialsExceptionParser();
+
+        RestStatus expected = RestStatus.UNAUTHORIZED;
+        RestStatus actual = ReflectionTestUtils.invokeMethod(parser, "responseStatus");
+
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/dev/codesupport/web/common/service/controller/throwparser/parser/HttpMediaTypeNotSupportedExceptionParserTest.java
+++ b/src/test/java/dev/codesupport/web/common/service/controller/throwparser/parser/HttpMediaTypeNotSupportedExceptionParserTest.java
@@ -1,0 +1,95 @@
+package dev.codesupport.web.common.service.controller.throwparser.parser;
+
+import dev.codesupport.web.common.service.controller.throwparser.AbstractThrowableParser;
+import dev.codesupport.web.common.service.service.RestStatus;
+import org.junit.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class HttpMediaTypeNotSupportedExceptionParserTest {
+
+    @Test
+    public void shouldReturnCorrectParserType() {
+        HttpMediaTypeNotSupportedExceptionParser parser = new HttpMediaTypeNotSupportedExceptionParser();
+
+        AbstractThrowableParser<HttpMediaTypeNotSupportedException> instancedParser = parser.instantiate();
+
+        assertTrue(instancedParser instanceof HttpMediaTypeNotSupportedExceptionParser);
+    }
+
+    @Test
+    public void shouldCreateNewInstance() {
+        HttpMediaTypeNotSupportedExceptionParser parser = new HttpMediaTypeNotSupportedExceptionParser();
+
+        AbstractThrowableParser<HttpMediaTypeNotSupportedException> firstInstance = parser.instantiate();
+        AbstractThrowableParser<HttpMediaTypeNotSupportedException> secondInstance = parser.instantiate();
+
+        assertNotSame(firstInstance, secondInstance);
+    }
+
+    @Test
+    public void shouldReturnCorrectMessage() {
+        String content = "content";
+        String type = "type";
+
+        HttpMediaTypeNotSupportedExceptionParser parser = new HttpMediaTypeNotSupportedExceptionParser();
+
+        HttpMediaTypeNotSupportedException mockException = mock(HttpMediaTypeNotSupportedException.class);
+
+        MediaType mockMediaType = mock(MediaType.class);
+
+        doReturn(content)
+                .when(mockMediaType)
+                .getType();
+
+        doReturn(type)
+                .when(mockMediaType)
+                .getSubtype();
+
+        doReturn(mockMediaType)
+                .when(mockException)
+                .getContentType();
+
+        ReflectionTestUtils.setField(parser, "throwable", mockException);
+
+        String expected = "Content type not supported: " + content + "/" + type;
+        String actual = parser.responseMessage();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldReturnCorrectMessageIfContentTypeNull() {
+        HttpMediaTypeNotSupportedExceptionParser parser = new HttpMediaTypeNotSupportedExceptionParser();
+
+        HttpMediaTypeNotSupportedException mockException = mock(HttpMediaTypeNotSupportedException.class);
+
+        doReturn(null)
+                .when(mockException)
+                .getContentType();
+
+        ReflectionTestUtils.setField(parser, "throwable", mockException);
+
+        String expected = "Content type not supported: ";
+        String actual = parser.responseMessage();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldReturnCorrectStatus() {
+        HttpMediaTypeNotSupportedExceptionParser parser = new HttpMediaTypeNotSupportedExceptionParser();
+
+        RestStatus expected = RestStatus.FAIL;
+        RestStatus actual = ReflectionTestUtils.invokeMethod(parser, "responseStatus");
+
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/dev/codesupport/web/common/service/controller/throwparser/parser/InvalidUserExceptionParserTest.java
+++ b/src/test/java/dev/codesupport/web/common/service/controller/throwparser/parser/InvalidUserExceptionParserTest.java
@@ -1,0 +1,64 @@
+package dev.codesupport.web.common.service.controller.throwparser.parser;
+
+import dev.codesupport.web.common.exception.InvalidUserException;
+import dev.codesupport.web.common.service.controller.throwparser.AbstractThrowableParser;
+import dev.codesupport.web.common.service.service.RestStatus;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class InvalidUserExceptionParserTest {
+
+    @Test
+    public void shouldReturnCorrectParserType() {
+        InvalidUserExceptionParser parser = new InvalidUserExceptionParser();
+
+        AbstractThrowableParser<InvalidUserException> instancedParser = parser.instantiate();
+
+        assertTrue(instancedParser instanceof InvalidUserExceptionParser);
+    }
+
+    @Test
+    public void shouldCreateNewInstance() {
+        InvalidUserExceptionParser parser = new InvalidUserExceptionParser();
+
+        AbstractThrowableParser<InvalidUserException> firstInstance = parser.instantiate();
+        AbstractThrowableParser<InvalidUserException> secondInstance = parser.instantiate();
+
+        assertNotSame(firstInstance, secondInstance);
+    }
+
+    @Test
+    public void shouldReturnCorrectMessage() {
+        String exceptionMessage = "Invalid user exception message";
+
+        InvalidUserExceptionParser parser = new InvalidUserExceptionParser();
+
+        InvalidUserException mockException = mock(InvalidUserException.class);
+
+        doReturn(exceptionMessage)
+                .when(mockException)
+                .getMessage();
+
+        ReflectionTestUtils.setField(parser, "throwable", mockException);
+
+        String actual = parser.responseMessage();
+
+        assertEquals(exceptionMessage, actual);
+    }
+
+    @Test
+    public void shouldReturnCorrectStatus() {
+        InvalidUserExceptionParser parser = new InvalidUserExceptionParser();
+
+        RestStatus expected = RestStatus.FAIL;
+        RestStatus actual = ReflectionTestUtils.invokeMethod(parser, "responseStatus");
+
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
Added basic authorization/access control to test endpoints.
send { "username" : "admin", "password" : "admin" } to */authenticate to test.
use returned token in authentication header "Bearer <token>" to test restricted endpoints.

Need to add firebase federation and implement a JWT utility to replace all stubs.