### PR TITLE
Feature/naming strategy

### DIFF
--- a/src/main/java/dev/codesupport/web/api/data/entity/UserEntity.java
+++ b/src/main/java/dev/codesupport/web/api/data/entity/UserEntity.java
@@ -14,7 +14,7 @@ import javax.persistence.PrePersist;
  * API contract with the persistent storage for the {@link dev.codesupport.web.domain.User} resource.
  */
 @Data
-@Entity(name = "User")
+@Entity
 public class UserEntity implements IdentifiableEntity<Long> {
 
     @Id

--- a/src/main/java/dev/codesupport/web/common/service/data/DataPhysicalNamingStrategy.java
+++ b/src/main/java/dev/codesupport/web/common/service/data/DataPhysicalNamingStrategy.java
@@ -1,0 +1,50 @@
+package dev.codesupport.web.common.service.data;
+
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.naming.PhysicalNamingStrategy;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+
+public class DataPhysicalNamingStrategy implements PhysicalNamingStrategy {
+
+    @Override
+    public Identifier toPhysicalCatalogName(Identifier identifier, JdbcEnvironment jdbcEnvironment) {
+        return convertToSnakeCase(identifier);
+    }
+
+    @Override
+    public Identifier toPhysicalSchemaName(Identifier identifier, JdbcEnvironment jdbcEnvironment) {
+        return convertToSnakeCase(identifier);
+    }
+
+    @Override
+    public Identifier toPhysicalTableName(Identifier identifier, JdbcEnvironment jdbcEnvironment) {
+        String tableName = identifier.getText().replaceFirst("Entity$", "");
+        return convertToSnakeCase(Identifier.toIdentifier(tableName));
+    }
+
+    @Override
+    public Identifier toPhysicalSequenceName(Identifier identifier, JdbcEnvironment jdbcEnvironment) {
+        return convertToSnakeCase(identifier);
+    }
+
+    @Override
+    public Identifier toPhysicalColumnName(Identifier identifier, JdbcEnvironment jdbcEnvironment) {
+        return convertToSnakeCase(identifier);
+    }
+
+    private Identifier convertToSnakeCase(final Identifier identifier) {
+        Identifier returnIdentifier;
+        if (identifier != null) {
+            final String regex = "([a-z])([A-Z])";
+            final String replacement = "$1_$2";
+            final String newName = identifier.getText()
+                    .replaceAll(regex, replacement)
+                    .toLowerCase();
+            returnIdentifier = Identifier.toIdentifier(newName);
+        } else {
+            returnIdentifier = null;
+        }
+        return returnIdentifier;
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,10 @@
 spring:
   profiles:
     active: @active.spring.profile@
+  jpa:
+    hibernate:
+      naming:
+        physical-strategy: dev.codesupport.web.common.service.data.DataPhysicalNamingStrategy
 security:
   jwt:
     issuer: CodeSupport.dev

--- a/src/test/java/dev/codesupport/testutils/controller/throwparsing/parser/ThrowableParser.java
+++ b/src/test/java/dev/codesupport/testutils/controller/throwparsing/parser/ThrowableParser.java
@@ -2,7 +2,9 @@ package dev.codesupport.testutils.controller.throwparsing.parser;
 
 import dev.codesupport.web.common.service.controller.throwparser.AbstractThrowableParser;
 import dev.codesupport.web.common.service.service.RestStatus;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor
 public class ThrowableParser extends AbstractThrowableParser<Throwable> {
 
     @Override

--- a/src/test/java/dev/codesupport/web/common/service/controller/throwparser/AbstractThrowableParserTest.java
+++ b/src/test/java/dev/codesupport/web/common/service/controller/throwparser/AbstractThrowableParserTest.java
@@ -1,5 +1,6 @@
 package dev.codesupport.web.common.service.controller.throwparser;
 
+import dev.codesupport.testutils.controller.throwparsing.parser.ThrowableParser;
 import dev.codesupport.web.common.service.service.RestResponse;
 import dev.codesupport.web.common.service.service.RestStatus;
 import org.junit.Test;
@@ -16,9 +17,7 @@ public class AbstractThrowableParserTest {
 
     @Test
     public void shouldReturnParserFromInstantiateMethod() {
-        //unchecked - this is fine for the purposes of this test.
-        //noinspection unchecked
-        AbstractThrowableParser<Throwable> parserSpy = Mockito.spy(AbstractThrowableParser.class);
+        AbstractThrowableParser<Throwable> parserSpy = Mockito.spy(new ThrowableParser());
 
         Throwable mockThrowable = mock(Throwable.class);
 
@@ -37,9 +36,7 @@ public class AbstractThrowableParserTest {
 
     @Test
     public void shouldHaveThrowableOnInstantiatedParser() {
-        //unchecked - this is fine for the purposes of this test.
-        //noinspection unchecked
-        AbstractThrowableParser<Throwable> parserSpy = Mockito.spy(AbstractThrowableParser.class);
+        AbstractThrowableParser<Throwable> parserSpy = Mockito.spy(new ThrowableParser());
 
         Throwable mockThrowable = mock(Throwable.class);
 
@@ -66,9 +63,7 @@ public class AbstractThrowableParserTest {
         RestResponse<Serializable> actual = new RestResponse<>();
         actual.setReferenceId(referenceId);
 
-        //unchecked - this is fine for the purposes of this test.
-        //noinspection unchecked
-        AbstractThrowableParser<Throwable> parserSpy = Mockito.spy(AbstractThrowableParser.class);
+        AbstractThrowableParser<Throwable> parserSpy = Mockito.spy(new ThrowableParser());
 
         doReturn(parserMessage)
                 .when(parserSpy)
@@ -90,12 +85,49 @@ public class AbstractThrowableParserTest {
 
     @Test
     public void shouldReturnFailedRestStatusByDefault() {
-        //unchecked - this is fine for the purposes of this test.
-        //noinspection unchecked
-        AbstractThrowableParser<Throwable> parserSpy = Mockito.spy(AbstractThrowableParser.class);
+        AbstractThrowableParser<Throwable> parserSpy = Mockito.spy(new ThrowableParser());
 
-        RestStatus expected = RestStatus.FAIL;
+        RestStatus expected = RestStatus.WARNING;
         RestStatus actual = parserSpy.responseStatus();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionIfNoClassParameterSet() {
+        //This is the point of this test.
+        //noinspection rawtypes
+        new AbstractThrowableParser() {
+            @Override
+            protected AbstractThrowableParser<Throwable> instantiate() {
+                return null;
+            }
+
+            @Override
+            protected String responseMessage() {
+                return null;
+            }
+        };
+    }
+
+    @Test
+    public void shouldSetCorrectThrowableClassType() {
+        AbstractThrowableParser<Throwable> parserSpy = Mockito.spy(new ThrowableParser());
+
+        Class<Throwable> expected = Throwable.class;
+        //This is fine for the purposes of this test.
+        //noinspection unchecked,rawtypes
+        Class<Throwable> actual = (Class) ReflectionTestUtils.getField(parserSpy, "throwableClassType");
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldReturnCorrectThrowableClassType() {
+        AbstractThrowableParser<Throwable> parserSpy = Mockito.spy(new ThrowableParser());
+
+        String expected = Throwable.class.getCanonicalName();
+        String actual = parserSpy.getThrowableClassType();
 
         assertEquals(expected, actual);
     }

--- a/src/test/java/dev/codesupport/web/common/service/controller/throwparser/ThrowableParserFactoryTest.java
+++ b/src/test/java/dev/codesupport/web/common/service/controller/throwparser/ThrowableParserFactoryTest.java
@@ -29,16 +29,24 @@ public class ThrowableParserFactoryTest {
 
     @Test
     public void shouldCreateExpectedParserIfExistsInMap() {
-        String throwableParserName = "throwableParser";
+        String throwableParserName = Throwable.class.getCanonicalName();
 
         ApplicationContext mockContext = mock(ApplicationContext.class);
 
+        // This is fine for the purpose of this test.
+        //noinspection rawtypes
         AbstractThrowableParser mockThrowableParser = mock(AbstractThrowableParser.class);
+
+        doReturn(throwableParserName)
+                .when(mockThrowableParser)
+                .getThrowableClassType();
 
         Throwable mockThrowable = mock(Throwable.class);
 
         Throwable mockRootThrowable = mock(Throwable.class);
 
+        // This is fine for the purpose of this test.
+        //noinspection rawtypes
         AbstractThrowableParser mockInstantiatedThrowableParser = mock(AbstractThrowableParser.class);
         ReflectionTestUtils.setField(mockInstantiatedThrowableParser, "throwable", mockRootThrowable);
 
@@ -69,6 +77,8 @@ public class ThrowableParserFactoryTest {
                 .when(factorySpy)
                 .getParserNameFromException(mockRootThrowable);
 
+        // This is fine for the purpose of this test.
+        //noinspection rawtypes
         AbstractThrowableParser actual = factorySpy.createParser(mockThrowable);
 
         assertEquals(mockInstantiatedThrowableParser, actual);
@@ -80,12 +90,16 @@ public class ThrowableParserFactoryTest {
 
         ApplicationContext mockContext = mock(ApplicationContext.class);
 
+        // This is fine for the purpose of this test.
+        //noinspection rawtypes
         AbstractThrowableParser mockThrowableParser = mock(AbstractThrowableParser.class);
 
         Throwable mockThrowable = mock(Throwable.class);
 
         Throwable mockRootThrowable = mock(Throwable.class);
 
+        // This is fine for the purpose of this test.
+        //noinspection rawtypes
         AbstractThrowableParser mockInstantiatedThrowableParser = mock(AbstractThrowableParser.class);
         ReflectionTestUtils.setField(mockInstantiatedThrowableParser, "throwable", mockRootThrowable);
 
@@ -111,6 +125,8 @@ public class ThrowableParserFactoryTest {
                 .when(factorySpy)
                 .getParserNameFromException(mockRootThrowable);
 
+        // This is fine for the purpose of this test.
+        //noinspection rawtypes
         AbstractThrowableParser actual = factorySpy.createParser(mockThrowable);
 
         assertEquals(new DefaultExceptionParser(), actual);
@@ -146,7 +162,7 @@ public class ThrowableParserFactoryTest {
 
     @Test
     public void shouldGetCorrectRootCauseIfFoundInMap() {
-        String throwableParserName = "throwableParser";
+        String throwableParserName = Throwable.class.getCanonicalName();
 
         ApplicationContext mockContext = mock(ApplicationContext.class);
 
@@ -187,7 +203,7 @@ public class ThrowableParserFactoryTest {
 
         ThrowableParserFactory factorySpy = Mockito.spy(new ThrowableParserFactory(mockContext));
 
-        String expected = "throwableParser";
+        String expected = Throwable.class.getCanonicalName();
 
         String actual = factorySpy.getParserNameFromException(new Throwable());
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -9,6 +9,8 @@ spring:
     open-in-view: false
     hibernate:
       ddl-auto: create-drop
+      naming:
+        physical-strategy: dev.codesupport.web.common.service.data.DataPhysicalNamingStrategy
   h2:
     console:
       enabled: true


### PR DESCRIPTION
Created naming strategy to remove "Entity" from table name, removing the need to specify an entity name in the annotation.