### PR TITLE
Small fixes and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,26 @@
 
 ``./mvn clean package`` - Deletes `target/` folder and repackages (preferred way to build)
 
+## Endpoints
+#### Resources
+
+`GET */api/user/v1/users` - Get all user info
+
+`GET */api/user/v1/users/{id}` - Get user info for specific user with id = {id}
+
+`POST */api/user/v1/users/` - Create (register) user.
+
+`GET */api/user/v1/profiles` - Get all user profiles
+
+`GET */api/user/v1/profiles/{id}` - Get user profile info for specific user with id = {id}
+
+#### Other
+
+`GET */healthcheck` - Perform app health check
+
+`POST */authenticate` - Authenticate credentials, returns a JWT
+
+`GET */authenticate/discord` - Link discord account, requires code (url param) and JWT (Authentication header) 
 
 ## Usage
 ### Build the App

--- a/src/main/java/dev/codesupport/web/api/controller/UserController.java
+++ b/src/main/java/dev/codesupport/web/api/controller/UserController.java
@@ -29,6 +29,6 @@ public interface UserController {
     RestResponse<UserStripped> getUserById(@PathVariable Long id);
 
     @PostMapping("/users")
-    RestResponse<UserStripped> registerUser(@RequestBody @Valid UserRegistration userRegistration);
+    RestResponse<String> registerUser(@RequestBody @Valid UserRegistration userRegistration);
 
 }

--- a/src/main/java/dev/codesupport/web/api/controller/UserControllerImpl.java
+++ b/src/main/java/dev/codesupport/web/api/controller/UserControllerImpl.java
@@ -35,8 +35,14 @@ public class UserControllerImpl implements UserController {
         return restResponse(service.getUserById(id));
     }
 
+    /**
+     * Registers a user, creating a user entry and returning a valid JWT
+     *
+     * @param userRegistration The user registration object with appriate information.
+     * @return A valid JWT for the created user.
+     */
     @Override
-    public RestResponse<UserStripped> registerUser(UserRegistration userRegistration) {
+    public RestResponse<String> registerUser(UserRegistration userRegistration) {
         return restResponse(service.registerUser(userRegistration));
     }
 

--- a/src/main/java/dev/codesupport/web/api/controller/UserProfileController.java
+++ b/src/main/java/dev/codesupport/web/api/controller/UserProfileController.java
@@ -17,10 +17,10 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public interface UserProfileController {
 
-    @GetMapping("/userprofiles")
+    @GetMapping("/profiles")
     RestResponse<UserProfile> getAllUserProfiles();
 
-    @GetMapping("/userprofiles/{id}")
+    @GetMapping("/profiles/{id}")
     RestResponse<UserProfile> getUserProfileById(@PathVariable Long id);
 
 }

--- a/src/main/java/dev/codesupport/web/api/data/entity/UserEntity.java
+++ b/src/main/java/dev/codesupport/web/api/data/entity/UserEntity.java
@@ -28,7 +28,7 @@ public class UserEntity implements IdentifiableEntity<Long> {
     private String alias;
     @Column(nullable = false)
     private String hashPassword;
-    private Long discordId;
+    private String discordId;
     @Column(nullable = false)
     private String email;
     private String avatarLink;

--- a/src/main/java/dev/codesupport/web/api/service/UserService.java
+++ b/src/main/java/dev/codesupport/web/api/service/UserService.java
@@ -21,6 +21,6 @@ public interface UserService {
 
     List<UserStripped> findAllUsers();
 
-    List<UserStripped> registerUser(UserRegistration userRegistration);
+    List<String> registerUser(UserRegistration userRegistration);
 
 }

--- a/src/main/java/dev/codesupport/web/common/security/AuthorizationService.java
+++ b/src/main/java/dev/codesupport/web/common/security/AuthorizationService.java
@@ -1,87 +1,13 @@
 package dev.codesupport.web.common.security;
 
-import dev.codesupport.web.api.data.entity.PermissionEntity;
-import dev.codesupport.web.api.data.entity.UserEntity;
-import dev.codesupport.web.api.data.repository.UserRepository;
-import dev.codesupport.web.common.exception.DisabledUserException;
-import dev.codesupport.web.common.exception.InvalidUserException;
-import dev.codesupport.web.common.security.hashing.HashingUtility;
-import dev.codesupport.web.common.security.jwt.JwtUtility;
 import dev.codesupport.web.common.security.models.UserDetails;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.stream.Collectors;
-
-/**
- * Service for performing logic to check authorizations.
- */
 @Service
-public class AuthorizationService {
+public interface AuthorizationService {
 
-    private final UserRepository userRepository;
-    private final HashingUtility hashingUtility;
-    private final JwtUtility jwtUtility;
+    String createTokenForEmailAndPassword(String email, String password);
 
-    @Autowired
-    public AuthorizationService(
-            UserRepository userRepository,
-            HashingUtility hashingUtility,
-            JwtUtility jwtUtility
-    ) {
-        this.userRepository = userRepository;
-        this.hashingUtility = hashingUtility;
-        this.jwtUtility = jwtUtility;
-    }
-
-    /**
-     * Creates a token if the given credentials are valid.
-     *
-     * @param email    The email for the credentials.
-     * @param password The clear text password for the credentials
-     * @return A token string if the credentials are valid
-     * @throws InvalidUserException If the authorization could not be completed for the given credentials.
-     */
-    public String createTokenForEmailAndPassword(String email, String password) {
-        UserDetails userDetails;
-
-        try {
-            userDetails = getUserDetailsByEmail(email);
-
-            if (hashingUtility.verifyPassword(password, userDetails.getPassword())) {
-                if (userDetails.isDisabled()) {
-                    throw new DisabledUserException("User is disabled.");
-                }
-            } else {
-                throw new InvalidUserException("Invalid user credentials.");
-            }
-        } catch (InvalidUserException | DisabledUserException e) {
-            throw new InvalidUserException("Could not authenticate user.", e);
-        }
-
-        return jwtUtility.generateToken(userDetails.getAlias(), userDetails.getEmail());
-    }
-
-    /**
-     * Gets {@link UserDetails} associated with the given email if it exists.
-     *
-     * @param email The email associated to the desired {@link UserDetails}
-     * @return The {@link UserDetails} associated to the given email, if it exists.
-     * @throws InvalidUserException If the email does not exist in the repository.
-     */
-    UserDetails getUserDetailsByEmail(String email) {
-        UserEntity userEntity = userRepository.findByEmail(email);
-        if (userEntity == null) {
-            throw new InvalidUserException("User does not exist for given email.");
-        }
-
-        return new UserDetails(
-                userEntity.getAlias(),
-                userEntity.getHashPassword(),
-                userEntity.getEmail(),
-                userEntity.getPermission().stream().map(PermissionEntity::getCode).collect(Collectors.toSet()),
-                userEntity.isDisabled()
-        );
-    }
+    UserDetails getUserDetailsByEmail(String email);
 
 }

--- a/src/main/java/dev/codesupport/web/common/security/AuthorizationServiceImpl.java
+++ b/src/main/java/dev/codesupport/web/common/security/AuthorizationServiceImpl.java
@@ -1,0 +1,89 @@
+package dev.codesupport.web.common.security;
+
+import dev.codesupport.web.api.data.entity.PermissionEntity;
+import dev.codesupport.web.api.data.entity.UserEntity;
+import dev.codesupport.web.api.data.repository.UserRepository;
+import dev.codesupport.web.common.exception.DisabledUserException;
+import dev.codesupport.web.common.exception.InvalidUserException;
+import dev.codesupport.web.common.security.hashing.HashingUtility;
+import dev.codesupport.web.common.security.jwt.JwtUtility;
+import dev.codesupport.web.common.security.models.UserDetails;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Collectors;
+
+/**
+ * Service for performing logic to check authorizations.
+ */
+@Component
+public class AuthorizationServiceImpl implements AuthorizationService {
+
+    private final UserRepository userRepository;
+    private final HashingUtility hashingUtility;
+    private final JwtUtility jwtUtility;
+
+    @Autowired
+    public AuthorizationServiceImpl(
+            UserRepository userRepository,
+            HashingUtility hashingUtility,
+            JwtUtility jwtUtility
+    ) {
+        this.userRepository = userRepository;
+        this.hashingUtility = hashingUtility;
+        this.jwtUtility = jwtUtility;
+    }
+
+    /**
+     * Creates a token if the given credentials are valid.
+     *
+     * @param email    The email for the credentials.
+     * @param password The clear text password for the credentials
+     * @return A token string if the credentials are valid
+     * @throws InvalidUserException If the authorization could not be completed for the given credentials.
+     */
+    @Override
+    public String createTokenForEmailAndPassword(String email, String password) {
+        UserDetails userDetails;
+
+        try {
+            userDetails = getUserDetailsByEmail(email);
+
+            if (hashingUtility.verifyPassword(password, userDetails.getPassword())) {
+                if (userDetails.isDisabled()) {
+                    throw new DisabledUserException("User is disabled.");
+                }
+            } else {
+                throw new InvalidUserException("Invalid user credentials.");
+            }
+        } catch (InvalidUserException | DisabledUserException e) {
+            throw new InvalidUserException("Could not authenticate user.", e);
+        }
+
+        return jwtUtility.generateToken(userDetails.getAlias(), userDetails.getEmail());
+    }
+
+    /**
+     * Gets {@link UserDetails} associated with the given email if it exists.
+     *
+     * @param email The email associated to the desired {@link UserDetails}
+     * @return The {@link UserDetails} associated to the given email, if it exists.
+     * @throws InvalidUserException If the email does not exist in the repository.
+     */
+    @Override
+    public UserDetails getUserDetailsByEmail(String email) {
+        UserEntity userEntity = userRepository.findByEmail(email);
+        if (userEntity == null) {
+            throw new InvalidUserException("User does not exist for given email.");
+        }
+
+        return new UserDetails(
+                userEntity.getAlias(),
+                userEntity.getHashPassword(),
+                userEntity.getEmail(),
+                userEntity.getPermission().stream().map(PermissionEntity::getCode).collect(Collectors.toSet()),
+                userEntity.isDisabled()
+        );
+    }
+
+}

--- a/src/main/java/dev/codesupport/web/common/security/HttpRequestFilter.java
+++ b/src/main/java/dev/codesupport/web/common/security/HttpRequestFilter.java
@@ -53,6 +53,9 @@ public class HttpRequestFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
 
+        response.setHeader("Access-Control-Allow-Origin", "*");
+        response.setHeader("Access-Control-Allow-Headers", "*");
+
         checkForJWToken(request);
 
         // Boilerplate call, invokes subsequent filter layers

--- a/src/main/java/dev/codesupport/web/common/service/controller/HealthCheckController.java
+++ b/src/main/java/dev/codesupport/web/common/service/controller/HealthCheckController.java
@@ -12,10 +12,10 @@ import static dev.codesupport.web.common.service.service.RestResponse.restRespon
  * Provides a simple healthcheck endpoint to check that the service is running.
  */
 @RestController
-public class HealthcheckController {
+public class HealthCheckController {
 
-    @GetMapping("/health")
-    public RestResponse<Serializable> getHealthCheck(){
+    @GetMapping("/healthcheck")
+    public RestResponse<Serializable> getHealthCheck() {
         return restResponse(null);
     }
 

--- a/src/main/java/dev/codesupport/web/common/service/http/RestRequest.java
+++ b/src/main/java/dev/codesupport/web/common/service/http/RestRequest.java
@@ -16,7 +16,7 @@ import java.util.Map;
  */
 @EqualsAndHashCode
 @ToString
-abstract class RestRequest<S extends Serializable, T extends Serializable> {
+public abstract class RestRequest<S extends Serializable, T extends Serializable> {
 
     protected String url;
     protected Map<String, String> headers;
@@ -51,8 +51,9 @@ abstract class RestRequest<S extends Serializable, T extends Serializable> {
 
     /**
      * Add parameter to be used in request
+     *
      * @param parameter Parameter name
-     * @param value Parameter value
+     * @param value     Parameter value
      * @return The class instance (builder pattern)
      */
     public RestRequest<S, T> withParameter(String parameter, String value) {
@@ -62,6 +63,7 @@ abstract class RestRequest<S extends Serializable, T extends Serializable> {
 
     /**
      * Add map of parameters to be used in request
+     *
      * @param parameters Map of parameters to add
      * @return The class instance (builder pattern)
      */
@@ -74,7 +76,7 @@ abstract class RestRequest<S extends Serializable, T extends Serializable> {
      * Add header to be used in request
      *
      * @param header Header name
-     * @param value Header value
+     * @param value  Header value
      * @return The class instance (builder pattern)
      */
     public RestRequest<S, T> withHeader(String header, String value) {

--- a/src/test/java/dev/codesupport/web/api/controllers/UserControllerImplTest.java
+++ b/src/test/java/dev/codesupport/web/api/controllers/UserControllerImplTest.java
@@ -103,22 +103,18 @@ public class UserControllerImplTest {
     }
 
     @Test
-    public void shouldReturnCorrectListOfUsersForCreateUsers() {
-        List<User> userList = userBuilders.stream()
-                .map(UserBuilder::buildDomain).collect(Collectors.toList());
-
-        List<UserStripped> returnedUsers = mapper().convertValue(userList, new TypeReference<List<UserStripped>>() {
-        });
+    public void shouldReturnCorrectResponseForRegisterUser() {
+        List<String> token = Collections.singletonList("Tokentokentoken");
 
         UserRegistration userRegistration = new UserRegistration();
         userRegistration.setAlias("user");
 
-        doReturn(returnedUsers)
+        doReturn(token)
                 .when(mockService)
                 .registerUser(userRegistration);
 
-        RestResponse<UserStripped> expected = new RestResponse<>(returnedUsers);
-        RestResponse<UserStripped> actual = controller.registerUser(userRegistration);
+        RestResponse<String> expected = new RestResponse<>(token);
+        RestResponse<String> actual = controller.registerUser(userRegistration);
 
         assertEquals(expected.getResponse(), actual.getResponse());
     }

--- a/src/test/java/dev/codesupport/web/common/security/AuthorizationServiceImplTest.java
+++ b/src/test/java/dev/codesupport/web/common/security/AuthorizationServiceImplTest.java
@@ -19,9 +19,12 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
-public class AuthorizationServiceTest {
+//S1192 - DRY is not applicable to unit tests.
+//S2068 - This is not a real password
+@SuppressWarnings({"squid:S1192", "squid:S2068"})
+public class AuthorizationServiceImplTest {
 
-    private static AuthorizationService spyService;
+    private static AuthorizationServiceImpl spyService;
 
     private static UserRepository mockUserRepository;
 
@@ -35,7 +38,7 @@ public class AuthorizationServiceTest {
         mockHashingUtility = mock(HashingUtility.class);
         mockJwtUtility = mock(JwtUtility.class);
 
-        spyService = spy(new AuthorizationService(mockUserRepository, mockHashingUtility, mockJwtUtility));
+        spyService = spy(new AuthorizationServiceImpl(mockUserRepository, mockHashingUtility, mockJwtUtility));
     }
 
     @Before

--- a/src/test/java/dev/codesupport/web/common/service/controller/AuthenticationControllerImplTest.java
+++ b/src/test/java/dev/codesupport/web/common/service/controller/AuthenticationControllerImplTest.java
@@ -16,6 +16,8 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
+//S2068 - This is not a real password
+@SuppressWarnings("squid:S2068")
 public class AuthenticationControllerImplTest {
 
     @Test(expected = InvalidUserException.class)

--- a/src/test/java/dev/codesupport/web/common/service/controller/HealthCheckControllerTest.java
+++ b/src/test/java/dev/codesupport/web/common/service/controller/HealthCheckControllerTest.java
@@ -1,0 +1,21 @@
+package dev.codesupport.web.common.service.controller;
+
+import dev.codesupport.web.common.service.service.RestResponse;
+import org.junit.Test;
+
+import java.io.Serializable;
+
+import static org.junit.Assert.assertNull;
+
+public class HealthCheckControllerTest {
+
+    @Test
+    public void shouldReturnNullResponseForHealthCheck() {
+        HealthCheckController controller = new HealthCheckController();
+
+        RestResponse<Serializable> actual = controller.getHealthCheck();
+
+        assertNull(actual.getResponse());
+    }
+
+}


### PR DESCRIPTION
Registering user returns JWT
Updated profile uri from `api/user/v1/userprofile` to `api/user/v1/profile`
Discord ID updated to string to match discord API response
Added AuthorizationService interface for setting access control annotations
Changed healthcheck endpoint from `/health` to `healthcheck`
Added CORS headers (temporary solution)
Updated RestRequest class access level to public
Updated unit tests to match changes