### PR TITLE
Feature/add alias lookup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
 
         <google-guava.version>28.1-jre</google-guava.version>
         <apache-commons-lang3.version>3.9</apache-commons-lang3.version>
+        <apache-commons-collections4.version>4.0</apache-commons-collections4.version>
         <lombok.version>1.18.8</lombok.version>
         <hibernate-jpamodelgen.version>6.0.0.Alpha2</hibernate-jpamodelgen.version>
         <swagger2.version>2.9.2</swagger2.version>
@@ -58,6 +59,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${apache-commons-lang3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>${apache-commons-collections4.version}</version>
         </dependency>
         <!-- Utilities -->
         <dependency>

--- a/src/main/java/dev/codesupport/web/api/controller/UserProfileController.java
+++ b/src/main/java/dev/codesupport/web/api/controller/UserProfileController.java
@@ -3,12 +3,15 @@ package dev.codesupport.web.api.controller;
 import dev.codesupport.web.common.service.service.RestResponse;
 import dev.codesupport.web.domain.User;
 import dev.codesupport.web.domain.UserProfile;
+import dev.codesupport.web.domain.UserProfileStripped;
+import dev.codesupport.web.domain.validation.annotation.AliasConstraint;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -16,16 +19,20 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("api/user/v1")
-@Api(tags = { "User" })
+@Api(tags = {"User"})
 @Validated
 public interface UserProfileController {
 
     @ApiOperation("Get all User Profiles")
     @GetMapping("/profiles")
-    RestResponse<UserProfile> getAllUserProfiles();
+    RestResponse<UserProfileStripped> getAllUserProfiles();
+
+    @ApiOperation("Get User Profile by alias")
+    @GetMapping(value = "/profiles", params = {"alias"})
+    RestResponse<UserProfile> getUserProfileByAlias(@RequestParam @AliasConstraint String alias);
 
     @ApiOperation("Get User Profile by id")
     @GetMapping("/profiles/{id}")
-    RestResponse<UserProfile> getUserProfileById(@PathVariable Long id);
+    RestResponse<UserProfileStripped> getUserProfileById(@PathVariable Long id);
 
 }

--- a/src/main/java/dev/codesupport/web/api/controller/UserProfileControllerImpl.java
+++ b/src/main/java/dev/codesupport/web/api/controller/UserProfileControllerImpl.java
@@ -4,6 +4,7 @@ import dev.codesupport.web.api.service.UserService;
 import dev.codesupport.web.common.service.service.RestResponse;
 import dev.codesupport.web.domain.User;
 import dev.codesupport.web.domain.UserProfile;
+import dev.codesupport.web.domain.UserProfileStripped;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
@@ -25,12 +26,17 @@ public class UserProfileControllerImpl implements UserProfileController {
     }
 
     @Override
-    public RestResponse<UserProfile> getAllUserProfiles() {
+    public RestResponse<UserProfileStripped> getAllUserProfiles() {
         return restResponse(service.findAllUserProfiles());
     }
 
     @Override
-    public RestResponse<UserProfile> getUserProfileById(Long id) {
+    public RestResponse<UserProfile> getUserProfileByAlias(String alias) {
+        return restResponse(service.getUserProfileByAlias(alias));
+    }
+
+    @Override
+    public RestResponse<UserProfileStripped> getUserProfileById(Long id) {
         return restResponse(service.getUserProfileById(id));
     }
 

--- a/src/main/java/dev/codesupport/web/api/data/repository/UserRepository.java
+++ b/src/main/java/dev/codesupport/web/api/data/repository/UserRepository.java
@@ -14,6 +14,8 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     boolean existsByEmail(String email);
 
-    UserEntity findByEmail(String alias);
+    UserEntity findByEmail(String email);
+
+    UserEntity findByAlias(String alias);
 
 }

--- a/src/main/java/dev/codesupport/web/api/service/UserService.java
+++ b/src/main/java/dev/codesupport/web/api/service/UserService.java
@@ -1,8 +1,10 @@
 package dev.codesupport.web.api.service;
 
 import dev.codesupport.web.domain.UserProfile;
+import dev.codesupport.web.domain.UserProfileStripped;
 import dev.codesupport.web.domain.UserRegistration;
 import dev.codesupport.web.domain.UserStripped;
+import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -13,9 +15,12 @@ import java.util.List;
 @Service
 public interface UserService {
 
-    List<UserProfile> getUserProfileById(Long id);
+    @PostAuthorize("hasPermission(returnObject, 'read')")
+    UserProfile getUserProfileByAlias(String alias);
 
-    List<UserProfile> findAllUserProfiles();
+    List<UserProfileStripped> getUserProfileById(Long id);
+
+    List<UserProfileStripped> findAllUserProfiles();
 
     List<UserStripped> getUserById(Long id);
 

--- a/src/main/java/dev/codesupport/web/api/service/UserServiceImpl.java
+++ b/src/main/java/dev/codesupport/web/api/service/UserServiceImpl.java
@@ -8,6 +8,7 @@ import dev.codesupport.web.common.service.service.CrudOperations;
 import dev.codesupport.web.common.util.MappingUtils;
 import dev.codesupport.web.domain.User;
 import dev.codesupport.web.domain.UserProfile;
+import dev.codesupport.web.domain.UserProfileStripped;
 import dev.codesupport.web.domain.UserRegistration;
 import dev.codesupport.web.domain.UserStripped;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,7 +24,9 @@ import java.util.List;
 public class UserServiceImpl implements UserService {
 
     private final CrudOperations<UserEntity, Long, User> userCrudOperations;
-    private final CrudOperations<UserEntity, Long, UserProfile> userProfileCrudOperations;
+    private final CrudOperations<UserEntity, Long, UserProfileStripped> userProfileCrudOperations;
+
+    private final UserRepository userRepository;
 
     private final HashingUtility hashingUtility;
 
@@ -36,7 +39,8 @@ public class UserServiceImpl implements UserService {
             JwtUtility jwtUtility
     ) {
         userCrudOperations = new CrudOperations<>(userRepository, UserEntity.class, User.class);
-        userProfileCrudOperations = new CrudOperations<>(userRepository, UserEntity.class, UserProfile.class);
+        userProfileCrudOperations = new CrudOperations<>(userRepository, UserEntity.class, UserProfileStripped.class);
+        this.userRepository = userRepository;
 
         this.hashingUtility = hashingUtility;
 
@@ -44,12 +48,19 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public List<UserProfile> getUserProfileById(Long id) {
+    public UserProfile getUserProfileByAlias(String alias) {
+        UserEntity userEntity = userRepository.findByAlias(alias);
+
+        return MappingUtils.convertToType(userEntity, UserProfile.class);
+    }
+
+    @Override
+    public List<UserProfileStripped> getUserProfileById(Long id) {
         return userProfileCrudOperations.getById(id);
     }
 
     @Override
-    public List<UserProfile> findAllUserProfiles() {
+    public List<UserProfileStripped> findAllUserProfiles() {
         return userProfileCrudOperations.getAll();
     }
 

--- a/src/main/java/dev/codesupport/web/common/security/AuthorizationService.java
+++ b/src/main/java/dev/codesupport/web/common/security/AuthorizationService.java
@@ -11,7 +11,7 @@ public interface AuthorizationService {
 
     UserDetails getUserDetailsByEmail(String email);
 
-    @PreAuthorize("hasPermission('discord', 'link_account')")
+    @PreAuthorize("hasPermission('discord', 'link')")
     void linkDiscord(String code);
 
 }

--- a/src/main/java/dev/codesupport/web/common/security/EmailPasswordAuthenticationToken.java
+++ b/src/main/java/dev/codesupport/web/common/security/EmailPasswordAuthenticationToken.java
@@ -1,0 +1,40 @@
+package dev.codesupport.web.common.security;
+
+import dev.codesupport.web.common.security.models.UserDetails;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+/**
+ * Token used with the spring authentication context
+ * <p>Exists simply so I can override getName() for a better response.</p>
+ */
+public class EmailPasswordAuthenticationToken extends UsernamePasswordAuthenticationToken {
+
+    public EmailPasswordAuthenticationToken(Object principal, Object credentials) {
+        super(principal, credentials);
+    }
+
+    public EmailPasswordAuthenticationToken(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+    }
+
+    /**
+     * Gets the name associated to the authentication token
+     *
+     * @return Email if principal is {@link UserDetails}, else returns default implementation.
+     */
+    @Override
+    public String getName() {
+        String name;
+
+        if (this.getPrincipal() instanceof UserDetails) {
+            name = ((UserDetails) this.getPrincipal()).getEmail();
+        } else {
+            name = super.getName();
+        }
+
+        return name;
+    }
+}

--- a/src/main/java/dev/codesupport/web/common/security/HttpRequestFilter.java
+++ b/src/main/java/dev/codesupport/web/common/security/HttpRequestFilter.java
@@ -7,7 +7,6 @@ import dev.codesupport.web.common.security.models.UserDetails;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
@@ -95,7 +94,7 @@ public class HttpRequestFilter extends OncePerRequestFilter {
         } catch (InvalidTokenException e) {
             // Doesn't matter, just log it for debugging and the service with return an unauthorized error.
             if (log.isDebugEnabled()) {
-                log.debug("Failed    to validate token", e);
+                log.debug("Failed to validate token", e);
             }
         }
     }
@@ -115,12 +114,12 @@ public class HttpRequestFilter extends OncePerRequestFilter {
         if (SecurityContextHolder.getContext().getAuthentication() == null) {
             UserDetails userDetails = authorizationService.getUserDetailsByEmail(email);
 
-            UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(
+            EmailPasswordAuthenticationToken emailPasswordAuthenticationToken = new EmailPasswordAuthenticationToken(
                     userDetails, null, userDetails.getAuthorities());
-            usernamePasswordAuthenticationToken
+            emailPasswordAuthenticationToken
                     .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
-            SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+            SecurityContextHolder.getContext().setAuthentication(emailPasswordAuthenticationToken);
         }
     }
 

--- a/src/main/java/dev/codesupport/web/common/security/access/AccessPermissionEvaluator.java
+++ b/src/main/java/dev/codesupport/web/common/security/access/AccessPermissionEvaluator.java
@@ -24,9 +24,13 @@ public class AccessPermissionEvaluator implements PermissionEvaluator {
      */
     @Override
     public boolean hasPermission(Authentication auth, Object targetDomainObject, Object permission) {
-        AbstractAccessEvaluator<?> evaluator = evaluatorFactory.getEvaluator(targetDomainObject);
+        boolean hasPermission = targetDomainObject == null;
+        if (!hasPermission) {
+            AbstractAccessEvaluator<?> evaluator = evaluatorFactory.getEvaluator(targetDomainObject, permission.toString().toLowerCase());
 
-        return evaluator.hasPermission(auth, targetDomainObject, permission.toString());
+            hasPermission = evaluator.hasPermission(auth, targetDomainObject);
+        }
+        return hasPermission;
     }
 
     /**
@@ -37,8 +41,12 @@ public class AccessPermissionEvaluator implements PermissionEvaluator {
      */
     @Override
     public boolean hasPermission(Authentication auth, Serializable targetId, String targetType, Object permission) {
-        AbstractAccessEvaluator<?> evaluator = evaluatorFactory.getEvaluator(targetType);
+        boolean hasPermission = targetId == null;
+        if (!hasPermission) {
+            AbstractAccessEvaluator<?> evaluator = evaluatorFactory.getEvaluatorByName(targetType.toLowerCase(), permission.toString().toLowerCase());
 
-        return evaluator.hasPermission(auth, targetId, permission.toString());
+            hasPermission = evaluator.hasPermission(auth, targetId);
+        }
+        return hasPermission;
     }
 }

--- a/src/main/java/dev/codesupport/web/common/security/access/Permission.java
+++ b/src/main/java/dev/codesupport/web/common/security/access/Permission.java
@@ -1,0 +1,11 @@
+package dev.codesupport.web.common.security.access;
+
+//unused - Eventually they will all be used. Maybe.
+@SuppressWarnings("unused")
+public enum Permission {
+    CREATE,
+    READ,
+    UPDATE,
+    DELETE,
+    LINK
+}

--- a/src/main/java/dev/codesupport/web/common/security/access/evaluator/AccountLinkEvaluator.java
+++ b/src/main/java/dev/codesupport/web/common/security/access/evaluator/AccountLinkEvaluator.java
@@ -2,6 +2,7 @@ package dev.codesupport.web.common.security.access.evaluator;
 
 import dev.codesupport.web.common.security.access.AbstractAccessEvaluator;
 import dev.codesupport.web.common.security.access.Accessor;
+import dev.codesupport.web.common.security.access.Permission;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
@@ -9,7 +10,11 @@ import org.springframework.stereotype.Component;
  * Determines access for linking discord account
  */
 @Component
-public class LinkAccountEvaluator extends AbstractAccessEvaluator<String> {
+public class AccountLinkEvaluator extends AbstractAccessEvaluator<String> {
+
+    public AccountLinkEvaluator() {
+        super(Permission.LINK);
+    }
 
     /**
      * Checks if user has right to link an account
@@ -18,11 +23,10 @@ public class LinkAccountEvaluator extends AbstractAccessEvaluator<String> {
      *
      * @param auth               The Authentication associated with the access evaluation
      * @param targetDomainObject The object associated with the access evaluation
-     * @param permission         The permission associated with the access evaluation
      * @return True if user is authenticated, False otherwise.
      */
     @Override
-    protected boolean hasPermissionCheck(Authentication auth, String targetDomainObject, String permission) {
+    protected boolean hasPermissionCheck(Authentication auth, String targetDomainObject) {
         // If you are a valid authenticated user, you can link your account.
         return isValidAuth(auth);
     }

--- a/src/main/java/dev/codesupport/web/common/security/access/evaluator/UserProfileReadEvaluator.java
+++ b/src/main/java/dev/codesupport/web/common/security/access/evaluator/UserProfileReadEvaluator.java
@@ -1,0 +1,53 @@
+package dev.codesupport.web.common.security.access.evaluator;
+
+import dev.codesupport.web.common.security.access.AbstractAccessEvaluator;
+import dev.codesupport.web.common.security.access.Permission;
+import dev.codesupport.web.domain.UserProfile;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+/**
+ * Determines access for reading User Profiles
+ */
+@Component
+public class UserProfileReadEvaluator extends AbstractAccessEvaluator<UserProfile> {
+
+    public UserProfileReadEvaluator() {
+        super(Permission.READ);
+    }
+
+    /**
+     * Checks if user has right to link an account
+     * <p>Only authenticated users (with valid JWT) are allowed to link their account, as this is needed
+     * to know who the user is.</p>
+     *
+     * @param auth        The Authentication associated with the access evaluation
+     * @param userProfile The object associated with the access evaluation
+     * @return True if user is authenticated, False otherwise.
+     */
+    @Override
+    protected boolean hasPermissionCheck(Authentication auth, UserProfile userProfile) {
+        if (isNotAllowedToSeeEmail(auth, userProfile)) {
+            userProfile.setEmail(null);
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks if the given Authentication object has permission to see the email of the given UserProfile
+     *
+     * @param auth        The Authentication associated with the access evaluation
+     * @param userProfile The object associated with the access evaluation
+     * @return True if Authentication can see UserProfile email, False otherwise
+     */
+    boolean isNotAllowedToSeeEmail(Authentication auth, UserProfile userProfile) {
+        return !isValidAuth(auth) ||
+                !StringUtils.equalsIgnoreCase(
+                        auth.getName(),
+                        userProfile.getEmail()
+                );
+    }
+
+}

--- a/src/main/java/dev/codesupport/web/common/service/controller/HealthCheckController.java
+++ b/src/main/java/dev/codesupport/web/common/service/controller/HealthCheckController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.Serializable;
+import java.util.Collections;
 
 import static dev.codesupport.web.common.service.service.RestResponse.restResponse;
 
@@ -14,13 +15,15 @@ import static dev.codesupport.web.common.service.service.RestResponse.restRespon
  * Provides a simple healthcheck endpoint to check that the service is running.
  */
 @RestController
-@Api(value = "Healthcheck", description = "Healthcheck endpoint", tags = { "Healthcheck" })
+@Api(value = "Healthcheck", description = "Healthcheck endpoint", tags = {"Healthcheck"})
 public class HealthCheckController {
 
     @ApiOperation("Validate health of application")
     @GetMapping("/healthcheck")
     public RestResponse<Serializable> getHealthCheck() {
-        return restResponse(null);
+        return restResponse(
+                Collections.emptyList()
+        );
     }
 
 }

--- a/src/main/java/dev/codesupport/web/common/service/controller/throwparser/parser/ConstraintViolationExceptionParser.java
+++ b/src/main/java/dev/codesupport/web/common/service/controller/throwparser/parser/ConstraintViolationExceptionParser.java
@@ -1,0 +1,43 @@
+package dev.codesupport.web.common.service.controller.throwparser.parser;
+
+import com.google.common.collect.Lists;
+import dev.codesupport.web.common.service.controller.throwparser.AbstractThrowableParser;
+import lombok.EqualsAndHashCode;
+import org.springframework.stereotype.Component;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Used to parse Java's {@link ConstraintViolationException} type throwables.
+ *
+ * @see ConstraintViolationException
+ * @see AbstractThrowableParser
+ */
+@Component
+@EqualsAndHashCode(callSuper = true)
+public class ConstraintViolationExceptionParser extends AbstractThrowableParser<ConstraintViolationException> {
+
+    @Override
+    protected AbstractThrowableParser<ConstraintViolationException> instantiate() {
+        return new ConstraintViolationExceptionParser();
+    }
+
+    @Override
+    protected String responseMessage() {
+        List<ConstraintViolation<?>> brokenConstraints = Lists.newArrayList(
+                throwable.getConstraintViolations().iterator()
+        );
+
+        String brokenConstraintMessage = brokenConstraints.stream().map(e -> {
+            List<Path.Node> pathNodes = Lists.newArrayList(e.getPropertyPath().iterator());
+            return "[" + pathNodes.get(pathNodes.size() - 1).toString() + " '" + e.getInvalidValue() + "': " + e.getMessage() + "]";
+        }).collect(Collectors.joining(","));
+
+        return "Invalid parameter(s): " + brokenConstraintMessage;
+
+    }
+}

--- a/src/main/java/dev/codesupport/web/common/service/service/RestResponse.java
+++ b/src/main/java/dev/codesupport/web/common/service/service/RestResponse.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import org.apache.commons.lang3.RandomStringUtils;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -16,6 +17,7 @@ public class RestResponse<T extends Serializable> {
 
     /**
      * The success status of the request
+     *
      * @see RestStatus
      */
     private RestStatus status;
@@ -42,6 +44,7 @@ public class RestResponse<T extends Serializable> {
 
     /**
      * Adds the provided resource list and automatically sets {@link RestStatus} and referenceId
+     *
      * @param response The resource list to add to the object
      */
     public RestResponse(List<T> response) {
@@ -50,11 +53,20 @@ public class RestResponse<T extends Serializable> {
     }
 
     /**
+     * Adds the provided resource as a list and automatically sets {@link RestStatus} and referenceId
+     *
+     * @param response The resource to add to the object
+     */
+    public RestResponse(T response) {
+        this(Collections.singletonList(response));
+    }
+
+    /**
      * Shortcut static method to generate a rest response
      * <p></p>
      *
      * @param response The resulting resource list following execution of the request
-     * @param <R> The serializable resource type associated with the request
+     * @param <R>      The serializable resource type associated with the request
      * @return a new {@link RestResponse} object, populated with the associated resource.
      */
     public static <R extends Serializable> RestResponse<R> restResponse(List<R> response) {
@@ -62,7 +74,20 @@ public class RestResponse<T extends Serializable> {
     }
 
     /**
+     * Shortcut static method to generate a rest response
+     * <p></p>
+     *
+     * @param response The resulting resource list following execution of the request
+     * @param <R>      The serializable resource type associated with the request
+     * @return a new {@link RestResponse} object, populated with the associated resource.
+     */
+    public static <R extends Serializable> RestResponse<R> restResponse(R response) {
+        return new RestResponse<>(response);
+    }
+
+    /**
      * Generates a random referenceId to associate to the request/response
+     *
      * @return a random referenceId, prepended with the time of the request in EPOCH
      */
     private String generateReferenceId() {

--- a/src/main/java/dev/codesupport/web/domain/UserProfileStripped.java
+++ b/src/main/java/dev/codesupport/web/domain/UserProfileStripped.java
@@ -7,17 +7,17 @@ import lombok.EqualsAndHashCode;
 import java.util.Set;
 
 /**
- * Used for returning basic User Profile information.
- * No additional permissions.
+ * Used for returning User Profile information.
+ * No additional permissions
  * No password.
+ * No email.
  */
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class UserProfile extends AbstractValidatable<Long> {
+public class UserProfileStripped extends AbstractValidatable<Long> {
 
     private Long id;
     private String alias;
-    private String email;
     private Long discordId;
     private String avatarLink;
     private boolean disabled;

--- a/src/main/java/dev/codesupport/web/domain/UserStripped.java
+++ b/src/main/java/dev/codesupport/web/domain/UserStripped.java
@@ -17,7 +17,6 @@ public class UserStripped extends AbstractValidatable<Long> {
 
     private Long id;
     private String alias;
-    private String email;
     private Long discordId;
     private String avatarLink;
     private boolean disabled;

--- a/src/main/java/dev/codesupport/web/domain/validation/annotation/AliasConstraint.java
+++ b/src/main/java/dev/codesupport/web/domain/validation/annotation/AliasConstraint.java
@@ -15,7 +15,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Constraint(validatedBy = AliasValidator.class)
-@Target({ElementType.METHOD, ElementType.FIELD})
+@Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AliasConstraint {
     /**

--- a/src/test/java/dev/codesupport/testutils/collection/MockNode.java
+++ b/src/test/java/dev/codesupport/testutils/collection/MockNode.java
@@ -1,0 +1,42 @@
+package dev.codesupport.testutils.collection;
+
+import javax.validation.ElementKind;
+import javax.validation.Path;
+
+public class MockNode implements Path.Node {
+
+    @Override
+    public String getName() {
+        return "testNode";
+    }
+
+    @Override
+    public boolean isInIterable() {
+        return true;
+    }
+
+    @Override
+    public Integer getIndex() {
+        return 0;
+    }
+
+    @Override
+    public Object getKey() {
+        return "test";
+    }
+
+    @Override
+    public ElementKind getKind() {
+        return null;
+    }
+
+    @Override
+    public <T extends Path.Node> T as(Class<T> aClass) {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "MockNode";
+    }
+}

--- a/src/test/java/dev/codesupport/web/api/controller/UserControllerImplTest.java
+++ b/src/test/java/dev/codesupport/web/api/controller/UserControllerImplTest.java
@@ -1,4 +1,4 @@
-package dev.codesupport.web.api.controllers;
+package dev.codesupport.web.api.controller;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.codesupport.web.common.service.service.RestResponse;
 import dev.codesupport.web.domain.User;
 import dev.codesupport.testutils.builders.UserBuilder;
-import dev.codesupport.web.api.controller.UserControllerImpl;
 import dev.codesupport.web.api.service.UserService;
 import dev.codesupport.web.domain.UserRegistration;
 import dev.codesupport.web.domain.UserStripped;

--- a/src/test/java/dev/codesupport/web/api/controller/UserProfileControllerImplTest.java
+++ b/src/test/java/dev/codesupport/web/api/controller/UserProfileControllerImplTest.java
@@ -1,14 +1,14 @@
-package dev.codesupport.web.api.controllers;
+package dev.codesupport.web.api.controller;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.codesupport.testutils.builders.UserBuilder;
-import dev.codesupport.web.api.controller.UserProfileControllerImpl;
 import dev.codesupport.web.api.service.UserService;
 import dev.codesupport.web.common.service.service.RestResponse;
 import dev.codesupport.web.domain.User;
 import dev.codesupport.web.domain.UserProfile;
+import dev.codesupport.web.domain.UserProfileStripped;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -68,15 +68,36 @@ public class UserProfileControllerImplTest {
         List<User> userList = userBuilders.stream()
                 .map(UserBuilder::buildDomain).collect(Collectors.toList());
 
-        List<UserProfile> returnedUsers = mapper().convertValue(userList, new TypeReference<List<UserProfile>>() {
-        });
+        List<UserProfileStripped> returnedUsers = mapper()
+                .convertValue(userList, new TypeReference<List<UserProfileStripped>>() {
+                });
 
         doReturn(returnedUsers)
                 .when(mockService)
                 .findAllUserProfiles();
 
-        RestResponse<UserProfile> expected = new RestResponse<>(returnedUsers);
-        RestResponse<UserProfile> actual = controller.getAllUserProfiles();
+        RestResponse<UserProfileStripped> expected = new RestResponse<>(returnedUsers);
+        RestResponse<UserProfileStripped> actual = controller.getAllUserProfiles();
+
+        assertEquals(expected.getResponse(), actual.getResponse());
+    }
+
+    @Test
+    public void shouldReturnCorrectResultsForGetUserProfileByAlias() {
+        String alias = "Username";
+
+        List<User> userList = userBuilders.stream()
+                .map(UserBuilder::buildDomain).collect(Collectors.toList());
+
+        UserProfile returnedUser = mapper()
+                .convertValue(userList.get(0), UserProfile.class);
+
+        doReturn(returnedUser)
+                .when(mockService)
+                .getUserProfileByAlias(alias);
+
+        RestResponse<UserProfile> expected = new RestResponse<>(returnedUser);
+        RestResponse<UserProfile> actual = controller.getUserProfileByAlias(alias);
 
         assertEquals(expected.getResponse(), actual.getResponse());
     }
@@ -88,15 +109,16 @@ public class UserProfileControllerImplTest {
         List<User> userList = userBuilders.stream()
                 .map(UserBuilder::buildDomain).collect(Collectors.toList());
 
-        List<UserProfile> returnedUsers = mapper().convertValue(userList, new TypeReference<List<UserProfile>>() {
-        });
+        List<UserProfileStripped> returnedUsers = mapper()
+                .convertValue(userList, new TypeReference<List<UserProfileStripped>>() {
+                });
 
         doReturn(returnedUsers)
                 .when(mockService)
                 .getUserProfileById(id);
 
-        RestResponse<UserProfile> expected = new RestResponse<>(returnedUsers);
-        RestResponse<UserProfile> actual = controller.getUserProfileById(id);
+        RestResponse<UserProfileStripped> expected = new RestResponse<>(returnedUsers);
+        RestResponse<UserProfileStripped> actual = controller.getUserProfileById(id);
 
         assertEquals(expected.getResponse(), actual.getResponse());
     }

--- a/src/test/java/dev/codesupport/web/api/data/repository/UserRepositoryTest.java
+++ b/src/test/java/dev/codesupport/web/api/data/repository/UserRepositoryTest.java
@@ -41,6 +41,16 @@ public class UserRepositoryTest {
     }
 
     @Test
+    public void shouldReturnCorrectUserByAlias() {
+        UserEntity userEntity = userRepository.findByAlias("Iffy");
+
+        String expected = "UserEntity(id=3, alias=Iffy, hashPassword=$2a$10$KuNmt9tVAOvzvcjsiTFzFudhC9bpJbhJfLKiVwwRYCaAPR2LXxJKS, discordId=null, email=if.fy@cs.dev, avatarLink=iffy.jpg, disabled=false, role=RoleEntity(id=1, code=admin, label=admin, permission=[PermissionEntity(id=1, code=write, label=write)]), permission=[], biography=Red sparkles and glitter, gitUrl= , country=CountryEntity(id=2, code=uk, label=United Kingdom), userAward=[UserAwardEntity(id=1, code=adv_cd_2019, label=Advent of Code 2019, description=A wonderful description)], joinDate=1570492800000)";
+        String actual = userEntity.toString();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void shouldReturnCorrectUserByEmail() {
         UserEntity userEntity = userRepository.findByEmail("if.fy@cs.dev");
 

--- a/src/test/java/dev/codesupport/web/api/service/UserServiceImplTest.java
+++ b/src/test/java/dev/codesupport/web/api/service/UserServiceImplTest.java
@@ -11,6 +11,7 @@ import dev.codesupport.web.common.security.jwt.JwtUtility;
 import dev.codesupport.web.common.service.service.CrudOperations;
 import dev.codesupport.web.domain.User;
 import dev.codesupport.web.domain.UserProfile;
+import dev.codesupport.web.domain.UserProfileStripped;
 import dev.codesupport.web.domain.UserRegistration;
 import dev.codesupport.web.domain.UserStripped;
 import org.junit.Before;
@@ -37,7 +38,9 @@ public class UserServiceImplTest {
     private static HashingUtility mockHashingUtility;
 
     private static CrudOperations<UserEntity, Long, User> mockUserCrudOperations;
-    private static CrudOperations<UserEntity, Long, UserProfile> mockUserProfileCrudOperations;
+    private static CrudOperations<UserEntity, Long, UserProfileStripped> mockUserProfileCrudOperations;
+
+    private static UserRepository mockUserRepository;
 
     private static List<User> getUserList;
 
@@ -55,14 +58,13 @@ public class UserServiceImplTest {
         //noinspection unchecked
         mockUserProfileCrudOperations = mock(CrudOperations.class);
 
+        mockUserRepository = mock(UserRepository.class);
         mockJwtUtility = mock(JwtUtility.class);
 
         ApplicationContext mockContext = mock(ApplicationContext.class);
 
         ReflectionTestUtils.setField(mockUserCrudOperations, "context", mockContext);
         ReflectionTestUtils.setField(mockUserProfileCrudOperations, "context", mockContext);
-
-        UserRepository mockUserRepository = mock(UserRepository.class);
 
         mockHashingUtility = mock(HashingUtility.class);
 
@@ -88,6 +90,7 @@ public class UserServiceImplTest {
         Mockito.reset(
                 mockUserCrudOperations,
                 mockUserProfileCrudOperations,
+                mockUserRepository,
                 mockHashingUtility,
                 mockJwtUtility
         );
@@ -99,39 +102,58 @@ public class UserServiceImplTest {
 
     @Test
     public void shouldReturnCorrectUsersWithFindAllUserProfiles() {
-        List<UserProfile> userProfiles = mapper()
-                .convertValue(getUserList, new TypeReference<List<UserProfile>>() {
+        List<UserProfileStripped> expected = mapper()
+                .convertValue(getUserList, new TypeReference<List<UserProfileStripped>>() {
                 });
 
-        doReturn(userProfiles)
+        doReturn(expected)
                 .when(mockUserProfileCrudOperations)
                 .getAll();
 
-        List<UserProfile> actual = service.findAllUserProfiles();
+        List<UserProfileStripped> actual = service.findAllUserProfiles();
 
-        assertEquals(userProfiles, actual);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldReturnCorrectUsersWithGetUserProfileByAlias() {
+        String alias = "username";
+
+        UserProfile expected = mapper()
+                .convertValue(getUserList.get(0), UserProfile.class);
+
+        UserEntity userEntity = mapper()
+                .convertValue(getUserList.get(0), UserEntity.class);
+
+        doReturn(userEntity)
+                .when(mockUserRepository)
+                .findByAlias(alias);
+
+        UserProfile actual = service.getUserProfileByAlias(alias);
+
+        assertEquals(expected, actual);
     }
 
     @Test
     public void shouldReturnCorrectUsersWithGetUserProfileById() {
         Long id = 1L;
 
-        List<UserProfile> userProfiles = mapper()
-                .convertValue(getUserList, new TypeReference<List<UserProfile>>() {
+        List<UserProfileStripped> expected = mapper()
+                .convertValue(getUserList, new TypeReference<List<UserProfileStripped>>() {
                 });
 
-        doReturn(userProfiles)
+        doReturn(expected)
                 .when(mockUserProfileCrudOperations)
                 .getById(id);
 
-        List<UserProfile> actual = service.getUserProfileById(id);
+        List<UserProfileStripped> actual = service.getUserProfileById(id);
 
-        assertEquals(userProfiles, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void shouldReturnCorrectUsersWithFindAllUsers() {
-        List<UserStripped> returnedUsers = mapper()
+        List<UserStripped> expected = mapper()
                 .convertValue(getUserList, new TypeReference<List<UserStripped>>() {
                 });
 
@@ -141,14 +163,14 @@ public class UserServiceImplTest {
 
         List<UserStripped> actual = service.findAllUsers();
 
-        assertEquals(returnedUsers, actual);
+        assertEquals(expected, actual);
     }
 
     @Test
     public void shouldReturnCorrectUsersWithGetUserById() {
         Long id = 1L;
 
-        List<UserStripped> returnedUsers = mapper()
+        List<UserStripped> expected = mapper()
                 .convertValue(getUserList, new TypeReference<List<UserStripped>>() {
                 });
 
@@ -158,7 +180,7 @@ public class UserServiceImplTest {
 
         List<UserStripped> actual = service.getUserById(id);
 
-        assertEquals(returnedUsers, actual);
+        assertEquals(expected, actual);
     }
 
     @Test

--- a/src/test/java/dev/codesupport/web/common/security/EmailPasswordAuthenticationTokenTest.java
+++ b/src/test/java/dev/codesupport/web/common/security/EmailPasswordAuthenticationTokenTest.java
@@ -1,0 +1,88 @@
+package dev.codesupport.web.common.security;
+
+import dev.codesupport.web.common.security.models.UserDetails;
+import org.junit.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class EmailPasswordAuthenticationTokenTest {
+
+    @Test
+    public void shouldCreateUsernamePasswordAuthenticationTokenBase() {
+        Object principal = "principal";
+        Object credentials = "credentials";
+
+        EmailPasswordAuthenticationToken actual = new EmailPasswordAuthenticationToken(
+                principal,
+                credentials
+        );
+
+        UsernamePasswordAuthenticationToken expected = new UsernamePasswordAuthenticationToken(
+                principal,
+                credentials
+        );
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldCreateUsernamePasswordAuthenticationTokenBaseWithAuthorities() {
+        Object principal = "principal";
+        Object credentials = "credentials";
+
+        EmailPasswordAuthenticationToken actual = new EmailPasswordAuthenticationToken(
+                principal,
+                credentials,
+                Collections.emptyList()
+        );
+
+        UsernamePasswordAuthenticationToken expected = new UsernamePasswordAuthenticationToken(
+                principal,
+                credentials,
+                Collections.emptyList()
+        );
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldGetCorrectNameIfUserDetailsSet() {
+        String email = "email";
+
+        Object principal = new UserDetails(
+                "alias",
+                "password",
+                email,
+                Collections.emptySet(),
+                false
+        );
+
+        Object credentials = "credentials";
+
+        EmailPasswordAuthenticationToken token = new EmailPasswordAuthenticationToken(
+                principal,
+                credentials,
+                Collections.emptyList()
+        );
+
+        assertEquals(email, token.getName());
+    }
+
+    @Test
+    public void shouldGetCorrectNameIfUserDetailsNotSet() {
+        Object principal = "principal";
+        Object credentials = "credentials";
+
+        EmailPasswordAuthenticationToken token = new EmailPasswordAuthenticationToken(
+                principal,
+                credentials,
+                Collections.emptyList()
+        );
+
+        assertEquals(principal, token.getName());
+    }
+
+}

--- a/src/test/java/dev/codesupport/web/common/security/HttpRequestFilterTest.java
+++ b/src/test/java/dev/codesupport/web/common/security/HttpRequestFilterTest.java
@@ -6,7 +6,6 @@ import dev.codesupport.web.common.security.jwt.JsonWebTokenFactory;
 import dev.codesupport.web.common.security.models.UserDetails;
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -298,7 +297,7 @@ public class HttpRequestFilterTest {
 
         httpRequestFilterSpy.configureSpringSecurityContext(email, mockRequest);
 
-        UsernamePasswordAuthenticationToken expected = new UsernamePasswordAuthenticationToken(
+        EmailPasswordAuthenticationToken expected = new EmailPasswordAuthenticationToken(
                 mockUserDetails,
                 null,
                 mockUserDetails.getAuthorities()

--- a/src/test/java/dev/codesupport/web/common/security/access/AccessPermissionEvaluatorTest.java
+++ b/src/test/java/dev/codesupport/web/common/security/access/AccessPermissionEvaluatorTest.java
@@ -3,6 +3,7 @@ package dev.codesupport.web.common.security.access;
 import org.junit.Test;
 import org.springframework.security.core.Authentication;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -10,9 +11,50 @@ import static org.mockito.Mockito.mock;
 public class AccessPermissionEvaluatorTest {
 
     @Test
+    public void shouldCorrectlyGetAndInvokeEvaluatorWithFailureByClassObject() {
+        String myObject = "my object";
+        String permission = "read";
+
+        Authentication mockAuthentication = mock(Authentication.class);
+
+        AccessEvaluatorFactory mockFactory = mock(AccessEvaluatorFactory.class);
+
+        AbstractAccessEvaluator<?> mockAccessEvaluator = mock(AbstractAccessEvaluator.class);
+
+        doReturn(false)
+                .when(mockAccessEvaluator)
+                .hasPermission(mockAuthentication, myObject);
+
+        doReturn(mockAccessEvaluator)
+                .when(mockFactory)
+                .getEvaluator(myObject, permission);
+
+        AccessPermissionEvaluator permissionEvaluator = new AccessPermissionEvaluator(mockFactory);
+
+        assertFalse(
+                permissionEvaluator.hasPermission(mockAuthentication, myObject, permission)
+        );
+    }
+
+    @Test
+    public void shouldCorrectlyGetAndInvokeEvaluatorWithSuccessIfObjectNullByClassObject() {
+        String permission = "read";
+
+        Authentication mockAuthentication = mock(Authentication.class);
+
+        AccessEvaluatorFactory mockFactory = mock(AccessEvaluatorFactory.class);
+
+        AccessPermissionEvaluator permissionEvaluator = new AccessPermissionEvaluator(mockFactory);
+
+        assertTrue(
+                permissionEvaluator.hasPermission(mockAuthentication, null, permission)
+        );
+    }
+
+    @Test
     public void shouldCorrectlyGetAndInvokeEvaluatorByClassObject() {
         String myObject = "my object";
-        String permission = "permission";
+        String permission = "read";
 
         Authentication mockAuthentication = mock(Authentication.class);
 
@@ -22,11 +64,11 @@ public class AccessPermissionEvaluatorTest {
 
         doReturn(true)
                 .when(mockAccessEvaluator)
-                .hasPermission(mockAuthentication, myObject, permission);
+                .hasPermission(mockAuthentication, myObject);
 
         doReturn(mockAccessEvaluator)
                 .when(mockFactory)
-                .getEvaluator(myObject);
+                .getEvaluator(myObject, permission);
 
         AccessPermissionEvaluator permissionEvaluator = new AccessPermissionEvaluator(mockFactory);
 
@@ -36,10 +78,53 @@ public class AccessPermissionEvaluatorTest {
     }
 
     @Test
+    public void shouldCorrectlyGetAndInvokeEvaluatorWithFailureByClassType() {
+        String targetId = "my object";
+        String targetType = "type";
+        String permission = "READ";
+
+        Authentication mockAuthentication = mock(Authentication.class);
+
+        AccessEvaluatorFactory mockFactory = mock(AccessEvaluatorFactory.class);
+
+        AbstractAccessEvaluator<?> mockAccessEvaluator = mock(AbstractAccessEvaluator.class);
+
+        doReturn(false)
+                .when(mockAccessEvaluator)
+                .hasPermission(mockAuthentication, targetId);
+
+        doReturn(mockAccessEvaluator)
+                .when(mockFactory)
+                .getEvaluatorByName(targetType.toLowerCase(), permission.toLowerCase());
+
+        AccessPermissionEvaluator permissionEvaluator = new AccessPermissionEvaluator(mockFactory);
+
+        assertFalse(
+                permissionEvaluator.hasPermission(mockAuthentication, targetId, targetType, permission)
+        );
+    }
+
+    @Test
+    public void shouldCorrectlyGetAndInvokeEvaluatorWithSuccessIfObjectNullByClassType() {
+        String targetType = "type";
+        String permission = "READ";
+
+        Authentication mockAuthentication = mock(Authentication.class);
+
+        AccessEvaluatorFactory mockFactory = mock(AccessEvaluatorFactory.class);
+
+        AccessPermissionEvaluator permissionEvaluator = new AccessPermissionEvaluator(mockFactory);
+
+        assertTrue(
+                permissionEvaluator.hasPermission(mockAuthentication, null, targetType, permission)
+        );
+    }
+
+    @Test
     public void shouldCorrectlyGetAndInvokeEvaluatorByClassType() {
         String targetId = "my object";
         String targetType = "type";
-        String permission = "permission";
+        String permission = "READ";
 
         Authentication mockAuthentication = mock(Authentication.class);
 
@@ -49,11 +134,11 @@ public class AccessPermissionEvaluatorTest {
 
         doReturn(true)
                 .when(mockAccessEvaluator)
-                .hasPermission(mockAuthentication, targetId, permission);
+                .hasPermission(mockAuthentication, targetId);
 
         doReturn(mockAccessEvaluator)
                 .when(mockFactory)
-                .getEvaluator(targetType);
+                .getEvaluatorByName(targetType.toLowerCase(), permission.toLowerCase());
 
         AccessPermissionEvaluator permissionEvaluator = new AccessPermissionEvaluator(mockFactory);
 

--- a/src/test/java/dev/codesupport/web/common/security/access/evaluator/AccountLinkEvaluatorTest.java
+++ b/src/test/java/dev/codesupport/web/common/security/access/evaluator/AccountLinkEvaluatorTest.java
@@ -1,52 +1,66 @@
 package dev.codesupport.web.common.security.access.evaluator;
 
 import dev.codesupport.web.common.security.access.Accessor;
+import dev.codesupport.web.common.security.access.Permission;
 import org.junit.Test;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-public class LinkAccountEvaluatorTest {
+public class AccountLinkEvaluatorTest {
+
+    @Test
+    public void shouldSetPermissionToLink() {
+        AccountLinkEvaluator evaluator = new AccountLinkEvaluator();
+
+        Permission actual = (Permission) ReflectionTestUtils.getField(
+                evaluator,
+                "permission"
+        );
+
+        assertEquals(Permission.LINK, actual);
+    }
 
     @Test
     public void shouldReturnFalseForHasPermissionIfNullAuth() {
-        LinkAccountEvaluator evaluator = new LinkAccountEvaluator();
+        AccountLinkEvaluator evaluator = new AccountLinkEvaluator();
 
         assertFalse(
-                evaluator.hasPermission(null, "", "")
+                evaluator.hasPermission(null, "")
         );
     }
 
     @Test
     public void shouldReturnFalseForHasPermissionIfAnonAuth() {
-        LinkAccountEvaluator evaluator = new LinkAccountEvaluator();
+        AccountLinkEvaluator evaluator = new AccountLinkEvaluator();
 
         Authentication mockAuthentication = mock(AnonymousAuthenticationToken.class);
 
         assertFalse(
-                evaluator.hasPermission(mockAuthentication, "", "")
+                evaluator.hasPermission(mockAuthentication, "")
         );
     }
 
     @Test
     public void shouldReturnTrueIfValidAuth() {
-        LinkAccountEvaluator evaluator = new LinkAccountEvaluator();
+        AccountLinkEvaluator evaluator = new AccountLinkEvaluator();
 
         Authentication mockAuthentication = mock(UsernamePasswordAuthenticationToken.class);
 
         assertTrue(
-                evaluator.hasPermission(mockAuthentication, "", "")
+                evaluator.hasPermission(mockAuthentication, "")
         );
     }
 
     @Test
     public void shouldGetCorrectAccessor() {
-        LinkAccountEvaluator evaluator = new LinkAccountEvaluator();
+        AccountLinkEvaluator evaluator = new AccountLinkEvaluator();
 
         assertEquals(Accessor.DISCORD, evaluator.getAccessor());
     }

--- a/src/test/java/dev/codesupport/web/common/security/access/evaluator/UserProfileReadEvaluatorTest.java
+++ b/src/test/java/dev/codesupport/web/common/security/access/evaluator/UserProfileReadEvaluatorTest.java
@@ -1,0 +1,142 @@
+package dev.codesupport.web.common.security.access.evaluator;
+
+import dev.codesupport.web.common.security.access.Permission;
+import dev.codesupport.web.domain.UserProfile;
+import org.junit.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+public class UserProfileReadEvaluatorTest {
+
+    @Test
+    public void shouldSetPermissionToRead() {
+        UserProfileReadEvaluator evaluator = new UserProfileReadEvaluator();
+
+        Permission actual = (Permission) ReflectionTestUtils.getField(
+                evaluator,
+                "permission"
+        );
+
+        assertEquals(Permission.READ, actual);
+    }
+
+    @Test
+    public void shouldDisplayEmailIfAllowed() {
+        String user = "User";
+        String email = "my@email.com";
+
+        UserProfile actual = new UserProfile();
+        actual.setAlias(user);
+        actual.setEmail(email);
+
+        Authentication mockAuthentication = mock(Authentication.class);
+        UserProfileReadEvaluator evaluatorSpy = spy(new UserProfileReadEvaluator());
+
+        doReturn(false)
+                .when(evaluatorSpy)
+                .isNotAllowedToSeeEmail(
+                        mockAuthentication,
+                        actual
+                );
+
+        UserProfile expected = new UserProfile();
+        expected.setAlias(user);
+        expected.setEmail(email);
+
+        evaluatorSpy.hasPermissionCheck(mockAuthentication, actual);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldEraseEmailIfNotAllowed() {
+        String user = "User";
+        String email = "my@email.com";
+
+        UserProfile actual = new UserProfile();
+        actual.setAlias(user);
+        actual.setEmail(email);
+
+        Authentication mockAuthentication = mock(Authentication.class);
+        UserProfileReadEvaluator evaluatorSpy = spy(new UserProfileReadEvaluator());
+
+        doReturn(true)
+                .when(evaluatorSpy)
+                .isNotAllowedToSeeEmail(
+                        mockAuthentication,
+                        actual
+                );
+
+        UserProfile expected = new UserProfile();
+        expected.setAlias(user);
+
+        evaluatorSpy.hasPermissionCheck(mockAuthentication, actual);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldReturnTrueForIsNotAllowedToSeeEmailIfInvalidAuth() {
+        UserProfileReadEvaluator evaluator = new UserProfileReadEvaluator();
+
+        assertTrue(
+                evaluator.isNotAllowedToSeeEmail(null, new UserProfile())
+        );
+    }
+
+    @Test
+    public void shouldReturnTrueForIsNotAllowedToSeeEmailIfEmailsDontMatch() {
+        Authentication mockAuthentication = mock(Authentication.class);
+
+        doReturn("email1")
+                .when(mockAuthentication)
+                .getName();
+
+        UserProfile mockUserProfile = mock(UserProfile.class);
+
+        //ResultOfMethodCallIgnored - Not invoking a method, we are creating a mock.
+        //noinspection ResultOfMethodCallIgnored
+        doReturn("email2")
+                .when(mockUserProfile)
+                .getEmail();
+
+        UserProfileReadEvaluator evaluator = new UserProfileReadEvaluator();
+
+        assertTrue(
+                evaluator.isNotAllowedToSeeEmail(mockAuthentication, mockUserProfile)
+        );
+    }
+
+    @Test
+    public void shouldReturnFalseForIsNotAllowedToSeeEmailIfEmailsMatch() {
+        String email = "email";
+
+        Authentication mockAuthentication = mock(Authentication.class);
+
+        doReturn(email)
+                .when(mockAuthentication)
+                .getName();
+
+        UserProfile mockUserProfile = mock(UserProfile.class);
+
+        //ResultOfMethodCallIgnored - Not invoking a method, we are creating a mock.
+        //noinspection ResultOfMethodCallIgnored
+        doReturn(email)
+                .when(mockUserProfile)
+                .getEmail();
+
+        UserProfileReadEvaluator evaluator = new UserProfileReadEvaluator();
+
+        assertFalse(
+                evaluator.isNotAllowedToSeeEmail(mockAuthentication, mockUserProfile)
+        );
+    }
+
+}

--- a/src/test/java/dev/codesupport/web/common/service/controller/HealthCheckControllerTest.java
+++ b/src/test/java/dev/codesupport/web/common/service/controller/HealthCheckControllerTest.java
@@ -4,8 +4,9 @@ import dev.codesupport.web.common.service.service.RestResponse;
 import org.junit.Test;
 
 import java.io.Serializable;
+import java.util.Collections;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertEquals;
 
 public class HealthCheckControllerTest {
 
@@ -15,7 +16,7 @@ public class HealthCheckControllerTest {
 
         RestResponse<Serializable> actual = controller.getHealthCheck();
 
-        assertNull(actual.getResponse());
+        assertEquals(Collections.emptyList(), actual.getResponse());
     }
 
 }

--- a/src/test/java/dev/codesupport/web/common/service/controller/throwparser/parser/ConstraintViolationExceptionParserTest.java
+++ b/src/test/java/dev/codesupport/web/common/service/controller/throwparser/parser/ConstraintViolationExceptionParserTest.java
@@ -1,0 +1,93 @@
+package dev.codesupport.web.common.service.controller.throwparser.parser;
+
+import com.google.common.collect.Sets;
+import dev.codesupport.testutils.collection.MockNode;
+import dev.codesupport.web.common.service.controller.throwparser.AbstractThrowableParser;
+import dev.codesupport.web.common.service.service.RestStatus;
+import org.apache.commons.collections4.IteratorUtils;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Path;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class ConstraintViolationExceptionParserTest {
+
+    @Test
+    public void shouldReturnCorrectParserType() {
+        ConstraintViolationExceptionParser parser = new ConstraintViolationExceptionParser();
+
+        AbstractThrowableParser<ConstraintViolationException> instancedParser = parser.instantiate();
+
+        assertTrue(instancedParser instanceof ConstraintViolationExceptionParser);
+    }
+
+    @Test
+    public void shouldCreateNewInstance() {
+        ConstraintViolationExceptionParser parser = new ConstraintViolationExceptionParser();
+
+        AbstractThrowableParser<ConstraintViolationException> firstInstance = parser.instantiate();
+        AbstractThrowableParser<ConstraintViolationException> secondInstance = parser.instantiate();
+
+        assertNotSame(firstInstance, secondInstance);
+    }
+
+    @Test
+    public void shouldReturnCorrectMessage() {
+        ConstraintViolationException mockException = mock(ConstraintViolationException.class);
+
+        //rawtypes - This is fine for the purposes of this test.
+        //noinspection rawtypes
+        ConstraintViolation mockConstraintViolation = mock(ConstraintViolation.class);
+
+        //unchecked - This is fine for the purposes of this test.
+        //noinspection unchecked
+        Set<ConstraintViolation<?>> mockConstraintSet = Sets.newHashSet(mockConstraintViolation);
+
+        doReturn((Path) () ->
+                IteratorUtils.arrayIterator(
+                        new Path.Node[]{new MockNode()}
+                )
+        )
+                .when(mockConstraintViolation)
+                .getPropertyPath();
+
+        doReturn("apple")
+                .when(mockConstraintViolation)
+                .getInvalidValue();
+
+        doReturn("test message")
+                .when(mockConstraintViolation)
+                .getMessage();
+
+        doReturn(mockConstraintSet)
+                .when(mockException)
+                .getConstraintViolations();
+
+        ConstraintViolationExceptionParser parser = new ConstraintViolationExceptionParser();
+
+        ReflectionTestUtils.setField(parser, "throwable", mockException);
+
+        String expected = "Invalid parameter(s): [MockNode 'apple': test message]";
+
+        assertEquals(expected, parser.responseMessage());
+    }
+
+    @Test
+    public void shouldReturnCorrectStatus() {
+        ServiceLayerExceptionParser parser = new ServiceLayerExceptionParser();
+
+        RestStatus expected = RestStatus.FAIL;
+        RestStatus actual = ReflectionTestUtils.invokeMethod(parser, "responseStatus");
+
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/dev/codesupport/web/common/service/service/RestResponseTest.java
+++ b/src/test/java/dev/codesupport/web/common/service/service/RestResponseTest.java
@@ -42,6 +42,29 @@ public class RestResponseTest {
     }
 
     @Test
+    public void shouldSetResponseWithDefaultPropertiesWithSingleObject() {
+        String string = "hello";
+
+        RestResponse<String> actual = new RestResponse<>(string);
+
+        RestResponse<String> expected = new RestResponse<>(string);
+        expected.setStatus(RestStatus.OK);
+        //This is a randomly generated value, and we don't care for the sake of this test
+        expected.setReferenceId(actual.getReferenceId());
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldCorrectlySetResponseWithSingleObject() {
+        String string = "hello";
+
+        RestResponse<String> actual = new RestResponse<>(string);
+
+        assertEquals(Collections.singletonList(string), actual.getResponse());
+    }
+
+    @Test
     public void shouldStaticallyCreateRestResponseWithDefaultProperties() {
         List<String> stringList = Collections.singletonList(
                 "hello"
@@ -50,6 +73,20 @@ public class RestResponseTest {
         RestResponse<String> actual = RestResponse.restResponse(stringList);
 
         RestResponse<String> expected = new RestResponse<>(stringList);
+        expected.setStatus(RestStatus.OK);
+        //This is a randomly generated value, and we don't care for the sake of this test
+        expected.setReferenceId(actual.getReferenceId());
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void shouldStaticallyCreateRestResponseWithDefaultPropertiesWithSingleObject() {
+        String string = "hello";
+
+        RestResponse<String> actual = RestResponse.restResponse(string);
+
+        RestResponse<String> expected = new RestResponse<>(string);
         expected.setStatus(RestStatus.OK);
         //This is a randomly generated value, and we don't care for the sake of this test
         expected.setReferenceId(actual.getReferenceId());


### PR DESCRIPTION
- Add alias lookup feature.
  - Return stripped (no email) UserProfile for most endpoints
  - Return full UserProfile for getByAlias() (Does auth check to see if you are this user, removes email from response if not)
- Adjust access control to accommodate needs
  - Evaluators are permission specific
  - Evaluators can handle objects or lists of objects
- Add constraint violation exception parser
- Add needed common library
- Update associated unit tests