### PR TITLE
Add auto wrapper for controller responses

### DIFF
--- a/src/main/java/dev/codesupport/web/api/controller/UserController.java
+++ b/src/main/java/dev/codesupport/web/api/controller/UserController.java
@@ -1,6 +1,6 @@
 package dev.codesupport.web.api.controller;
 
-import dev.codesupport.web.common.service.service.RestResponse;
+import dev.codesupport.web.domain.TokenResponse;
 import dev.codesupport.web.domain.User;
 import dev.codesupport.web.domain.UserRegistration;
 import dev.codesupport.web.domain.UserStripped;
@@ -15,26 +15,27 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import java.util.List;
 
 /**
  * Defines endpoints and validations for the associated API Contract for the {@link User} resource.
  */
 @RestController
 @RequestMapping("api/user/v1")
-@Api(value = "User", description = "REST API for User", tags = { "User" })
+@Api(value = "User", description = "REST API for User", tags = {"User"})
 @Validated
 public interface UserController {
 
     @ApiOperation("Get all Users")
     @GetMapping("/users")
-    RestResponse<UserStripped> getAllUsers();
+    List<UserStripped> getAllUsers();
 
     @ApiOperation("Get User by id")
     @GetMapping("/users/{id}")
-    RestResponse<UserStripped> getUserById(@PathVariable Long id);
+    UserStripped getUserById(@PathVariable Long id);
 
     @ApiOperation("Register User")
     @PostMapping("/users")
-    RestResponse<String> registerUser(@RequestBody @Valid UserRegistration userRegistration);
+    TokenResponse registerUser(@RequestBody @Valid UserRegistration userRegistration);
 
 }

--- a/src/main/java/dev/codesupport/web/api/controller/UserControllerImpl.java
+++ b/src/main/java/dev/codesupport/web/api/controller/UserControllerImpl.java
@@ -1,7 +1,7 @@
 package dev.codesupport.web.api.controller;
 
 import dev.codesupport.web.api.service.UserService;
-import dev.codesupport.web.common.service.service.RestResponse;
+import dev.codesupport.web.domain.TokenResponse;
 import dev.codesupport.web.domain.User;
 import dev.codesupport.web.domain.UserRegistration;
 import dev.codesupport.web.domain.UserStripped;
@@ -9,7 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
-import static dev.codesupport.web.common.service.service.RestResponse.restResponse;
+import java.util.List;
 
 /**
  * API Contract implementation for the {@link User} resource.
@@ -26,13 +26,13 @@ public class UserControllerImpl implements UserController {
     }
 
     @Override
-    public RestResponse<UserStripped> getAllUsers() {
-        return restResponse(service.findAllUsers());
+    public List<UserStripped> getAllUsers() {
+        return service.findAllUsers();
     }
 
     @Override
-    public RestResponse<UserStripped> getUserById(Long id) {
-        return restResponse(service.getUserById(id));
+    public UserStripped getUserById(Long id) {
+        return service.getUserById(id);
     }
 
     /**
@@ -42,8 +42,8 @@ public class UserControllerImpl implements UserController {
      * @return A valid JWT for the created user.
      */
     @Override
-    public RestResponse<String> registerUser(UserRegistration userRegistration) {
-        return restResponse(service.registerUser(userRegistration));
+    public TokenResponse registerUser(UserRegistration userRegistration) {
+        return service.registerUser(userRegistration);
     }
 
 }

--- a/src/main/java/dev/codesupport/web/api/controller/UserProfileController.java
+++ b/src/main/java/dev/codesupport/web/api/controller/UserProfileController.java
@@ -1,6 +1,5 @@
 package dev.codesupport.web.api.controller;
 
-import dev.codesupport.web.common.service.service.RestResponse;
 import dev.codesupport.web.domain.User;
 import dev.codesupport.web.domain.UserProfile;
 import dev.codesupport.web.domain.UserProfileStripped;
@@ -14,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 /**
  * Defines endpoints and validations for the associated API Contract for the {@link User} resource.
  */
@@ -25,14 +26,14 @@ public interface UserProfileController {
 
     @ApiOperation("Get all User Profiles")
     @GetMapping("/profiles")
-    RestResponse<UserProfileStripped> getAllUserProfiles();
+    List<UserProfileStripped> getAllUserProfiles();
 
     @ApiOperation("Get User Profile by alias")
     @GetMapping(value = "/profiles", params = {"alias"})
-    RestResponse<UserProfile> getUserProfileByAlias(@RequestParam @AliasConstraint String alias);
+    UserProfile getUserProfileByAlias(@RequestParam @AliasConstraint String alias);
 
     @ApiOperation("Get User Profile by id")
     @GetMapping("/profiles/{id}")
-    RestResponse<UserProfileStripped> getUserProfileById(@PathVariable Long id);
+    UserProfileStripped getUserProfileById(@PathVariable Long id);
 
 }

--- a/src/main/java/dev/codesupport/web/api/controller/UserProfileControllerImpl.java
+++ b/src/main/java/dev/codesupport/web/api/controller/UserProfileControllerImpl.java
@@ -1,7 +1,6 @@
 package dev.codesupport.web.api.controller;
 
 import dev.codesupport.web.api.service.UserService;
-import dev.codesupport.web.common.service.service.RestResponse;
 import dev.codesupport.web.domain.User;
 import dev.codesupport.web.domain.UserProfile;
 import dev.codesupport.web.domain.UserProfileStripped;
@@ -9,7 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.annotation.Validated;
 
-import static dev.codesupport.web.common.service.service.RestResponse.restResponse;
+import java.util.List;
 
 /**
  * API Contract implementation for the {@link User} resource.
@@ -26,18 +25,18 @@ public class UserProfileControllerImpl implements UserProfileController {
     }
 
     @Override
-    public RestResponse<UserProfileStripped> getAllUserProfiles() {
-        return restResponse(service.findAllUserProfiles());
+    public List<UserProfileStripped> getAllUserProfiles() {
+        return service.findAllUserProfiles();
     }
 
     @Override
-    public RestResponse<UserProfile> getUserProfileByAlias(String alias) {
-        return restResponse(service.getUserProfileByAlias(alias));
+    public UserProfile getUserProfileByAlias(String alias) {
+        return service.getUserProfileByAlias(alias);
     }
 
     @Override
-    public RestResponse<UserProfileStripped> getUserProfileById(Long id) {
-        return restResponse(service.getUserProfileById(id));
+    public UserProfileStripped getUserProfileById(Long id) {
+        return service.getUserProfileById(id);
     }
 
 }

--- a/src/main/java/dev/codesupport/web/api/service/UserService.java
+++ b/src/main/java/dev/codesupport/web/api/service/UserService.java
@@ -1,5 +1,6 @@
 package dev.codesupport.web.api.service;
 
+import dev.codesupport.web.domain.TokenResponse;
 import dev.codesupport.web.domain.UserProfile;
 import dev.codesupport.web.domain.UserProfileStripped;
 import dev.codesupport.web.domain.UserRegistration;
@@ -18,14 +19,14 @@ public interface UserService {
     @PostAuthorize("hasPermission(returnObject, 'read')")
     UserProfile getUserProfileByAlias(String alias);
 
-    List<UserProfileStripped> getUserProfileById(Long id);
+    UserProfileStripped getUserProfileById(Long id);
 
     List<UserProfileStripped> findAllUserProfiles();
 
-    List<UserStripped> getUserById(Long id);
+    UserStripped getUserById(Long id);
 
     List<UserStripped> findAllUsers();
 
-    List<String> registerUser(UserRegistration userRegistration);
+    TokenResponse registerUser(UserRegistration userRegistration);
 
 }

--- a/src/main/java/dev/codesupport/web/api/service/UserServiceImpl.java
+++ b/src/main/java/dev/codesupport/web/api/service/UserServiceImpl.java
@@ -6,6 +6,7 @@ import dev.codesupport.web.common.security.hashing.HashingUtility;
 import dev.codesupport.web.common.security.jwt.JwtUtility;
 import dev.codesupport.web.common.service.service.CrudOperations;
 import dev.codesupport.web.common.util.MappingUtils;
+import dev.codesupport.web.domain.TokenResponse;
 import dev.codesupport.web.domain.User;
 import dev.codesupport.web.domain.UserProfile;
 import dev.codesupport.web.domain.UserProfileStripped;
@@ -14,7 +15,6 @@ import dev.codesupport.web.domain.UserStripped;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -55,7 +55,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public List<UserProfileStripped> getUserProfileById(Long id) {
+    public UserProfileStripped getUserProfileById(Long id) {
         return userProfileCrudOperations.getById(id);
     }
 
@@ -65,8 +65,8 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public List<UserStripped> getUserById(Long id) {
-        List<User> users = userCrudOperations.getById(id);
+    public UserStripped getUserById(Long id) {
+        User users = userCrudOperations.getById(id);
 
         return MappingUtils.convertToType(users, UserStripped.class);
     }
@@ -79,7 +79,7 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public List<String> registerUser(UserRegistration userRegistration) {
+    public TokenResponse registerUser(UserRegistration userRegistration) {
         User user = MappingUtils.convertToType(userRegistration, User.class);
 
         user.setHashPassword(
@@ -88,9 +88,9 @@ public class UserServiceImpl implements UserService {
 
         List<User> users = userCrudOperations.createEntity(user);
 
-        final String token = jwtUtility.generateToken(users.get(0).getAlias(), users.get(0).getEmail());
-
-        return Collections.singletonList(token);
+        return new TokenResponse(
+                jwtUtility.generateToken(users.get(0).getAlias(), users.get(0).getEmail())
+        );
     }
 
 }

--- a/src/main/java/dev/codesupport/web/common/security/AuthorizationService.java
+++ b/src/main/java/dev/codesupport/web/common/security/AuthorizationService.java
@@ -1,13 +1,14 @@
 package dev.codesupport.web.common.security;
 
 import dev.codesupport.web.common.security.models.UserDetails;
+import dev.codesupport.web.domain.TokenResponse;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface AuthorizationService {
 
-    String createTokenForEmailAndPassword(String email, String password);
+    TokenResponse createTokenForEmailAndPassword(String email, String password);
 
     UserDetails getUserDetailsByEmail(String email);
 

--- a/src/main/java/dev/codesupport/web/common/security/AuthorizationServiceImpl.java
+++ b/src/main/java/dev/codesupport/web/common/security/AuthorizationServiceImpl.java
@@ -15,6 +15,7 @@ import dev.codesupport.web.common.security.models.DiscordUser;
 import dev.codesupport.web.common.security.models.UserDetails;
 import dev.codesupport.web.common.service.http.HttpClient;
 import dev.codesupport.web.common.service.http.HttpMethod;
+import dev.codesupport.web.domain.TokenResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
@@ -58,7 +59,7 @@ public class AuthorizationServiceImpl implements AuthorizationService {
      * @throws InvalidUserException If the authorization could not be completed for the given credentials.
      */
     @Override
-    public String createTokenForEmailAndPassword(String email, String password) {
+    public TokenResponse createTokenForEmailAndPassword(String email, String password) {
         UserDetails userDetails;
 
         try {
@@ -75,7 +76,9 @@ public class AuthorizationServiceImpl implements AuthorizationService {
             throw new InvalidUserException("Could not authenticate user.", e);
         }
 
-        return jwtUtility.generateToken(userDetails.getAlias(), userDetails.getEmail());
+        return new TokenResponse(
+                jwtUtility.generateToken(userDetails.getAlias(), userDetails.getEmail())
+        );
     }
 
     /**

--- a/src/main/java/dev/codesupport/web/common/security/HttpRequestFilter.java
+++ b/src/main/java/dev/codesupport/web/common/security/HttpRequestFilter.java
@@ -58,7 +58,6 @@ public class HttpRequestFilter extends OncePerRequestFilter {
 
         checkForJWToken(request);
 
-        // Boilerplate call, invokes subsequent filter layers
         chain.doFilter(request, response);
     }
 

--- a/src/main/java/dev/codesupport/web/common/service/controller/AuthenticationController.java
+++ b/src/main/java/dev/codesupport/web/common/service/controller/AuthenticationController.java
@@ -1,10 +1,10 @@
 package dev.codesupport.web.common.service.controller;
 
 import dev.codesupport.web.common.security.models.AuthenticationRequest;
-import dev.codesupport.web.common.service.service.RestResponse;
+import dev.codesupport.web.domain.OkResponse;
+import dev.codesupport.web.domain.TokenResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,23 +13,22 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
-import java.io.Serializable;
 
 /**
  * Controller interface for defining mappings and annotations.
  * <p>Spring requires this to be an interface to work.</p>
  */
 @RestController
-@Api(value = "Authentication", description = "REST API for Authentications", tags = { "Authentication" })
+@Api(value = "Authentication", description = "REST API for Authentications", tags = {"Authentication"})
 @Validated
 public interface AuthenticationController {
 
     @ApiOperation("Authenticate user credentials")
     @PostMapping(value = "/authenticate")
-    ResponseEntity<RestResponse<String>> authenticate(@RequestBody @Valid AuthenticationRequest authenticationRequest);
+    TokenResponse authenticate(@RequestBody @Valid AuthenticationRequest authenticationRequest);
 
     @ApiOperation("Authenticate and link discord account")
     @GetMapping(value = "/authenticate/discord")
-    ResponseEntity<RestResponse<Serializable>> linkDiscord(@RequestParam String code);
+    OkResponse linkDiscord(@RequestParam String code);
 
 }

--- a/src/main/java/dev/codesupport/web/common/service/controller/AuthenticationControllerImpl.java
+++ b/src/main/java/dev/codesupport/web/common/service/controller/AuthenticationControllerImpl.java
@@ -1,16 +1,11 @@
 package dev.codesupport.web.common.service.controller;
 
-import com.google.common.annotations.VisibleForTesting;
-import dev.codesupport.web.common.security.models.AuthenticationRequest;
 import dev.codesupport.web.common.security.AuthorizationService;
-import dev.codesupport.web.common.service.service.RestResponse;
+import dev.codesupport.web.common.security.models.AuthenticationRequest;
+import dev.codesupport.web.domain.OkResponse;
+import dev.codesupport.web.domain.TokenResponse;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
-
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Accepts post requests containing username/password credentials
@@ -38,15 +33,11 @@ public class AuthenticationControllerImpl implements AuthenticationController {
      * @param authenticationRequest The {@link AuthenticationRequest} body
      * @return The encoded JWT string if authentication passes.
      */
-    public ResponseEntity<RestResponse<String>> authenticate(AuthenticationRequest authenticationRequest) {
+    public TokenResponse authenticate(AuthenticationRequest authenticationRequest) {
         String email = authenticationRequest.getEmail();
         String password = authenticationRequest.getPassword();
 
-        final String token = authorizationService.createTokenForEmailAndPassword(email, password);
-
-        return ResponseEntity.ok(
-                getRestResponse(Collections.singletonList(token))
-        );
+        return authorizationService.createTokenForEmailAndPassword(email, password);
     }
 
     /**
@@ -58,24 +49,10 @@ public class AuthenticationControllerImpl implements AuthenticationController {
      * @return Returns simple OK - 200 response if successful
      */
     @Override
-    public ResponseEntity<RestResponse<Serializable>> linkDiscord(String code) {
+    public OkResponse linkDiscord(String code) {
         authorizationService.linkDiscord(code);
 
-        return ResponseEntity.ok(
-                RestResponse.restResponse(Collections.singletonList("Ok"))
-        );
-    }
-
-    /**
-     * Returns a new instance of {@link RestResponse}
-     * <p>This exists to make unit testing easier</p>
-     *
-     * @param objectList The resources to include in the {@link RestResponse}
-     * @return The expected {@link RestResponse}
-     */
-    @VisibleForTesting
-    RestResponse<String> getRestResponse(List<String> objectList) {
-        return new RestResponse<>(objectList);
+        return new OkResponse();
     }
 
 }

--- a/src/main/java/dev/codesupport/web/common/service/controller/HealthCheckController.java
+++ b/src/main/java/dev/codesupport/web/common/service/controller/HealthCheckController.java
@@ -1,15 +1,10 @@
 package dev.codesupport.web.common.service.controller;
 
-import dev.codesupport.web.common.service.service.RestResponse;
+import dev.codesupport.web.domain.OkResponse;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.io.Serializable;
-import java.util.Collections;
-
-import static dev.codesupport.web.common.service.service.RestResponse.restResponse;
 
 /**
  * Provides a simple healthcheck endpoint to check that the service is running.
@@ -20,10 +15,8 @@ public class HealthCheckController {
 
     @ApiOperation("Validate health of application")
     @GetMapping("/healthcheck")
-    public RestResponse<Serializable> getHealthCheck() {
-        return restResponse(
-                Collections.emptyList()
-        );
+    public OkResponse getHealthCheck() {
+        return new OkResponse();
     }
 
 }

--- a/src/main/java/dev/codesupport/web/common/service/http/AutoWrapHttpResponses.java
+++ b/src/main/java/dev/codesupport/web/common/service/http/AutoWrapHttpResponses.java
@@ -1,0 +1,75 @@
+package dev.codesupport.web.common.service.http;
+
+import dev.codesupport.web.common.exception.InternalServiceException;
+import dev.codesupport.web.common.service.service.RestResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Intercepts objects returned from controllers and wraps them in a standard response.
+ */
+@ControllerAdvice
+public class AutoWrapHttpResponses implements ResponseBodyAdvice<Object> {
+
+    /**
+     * Methods that should not have their return objects wrapped
+     */
+    private static final List<String> NON_SUPPORTED_METHODS;
+
+    static {
+        NON_SUPPORTED_METHODS = Arrays.asList(
+                "handleerror",
+                "uiconfiguration",
+                "securityconfiguration",
+                "swaggerresources",
+                "getdocumentation"
+
+        );
+    }
+
+    /**
+     * Determines which return objects will be returned
+     * <p>Currently configured to wrap anything that does NOT come from the error handler</p>
+     *
+     * @param returnType    ?
+     * @param converterType The class type of the returned object
+     * @return True if this wrapper supports the returned object, False otherwise
+     */
+    @Override
+    public boolean supports(MethodParameter returnType, Class converterType) {
+        return returnType.getMethod() == null ||
+                !NON_SUPPORTED_METHODS.contains(
+                        returnType.getMethod().getName().toLowerCase()
+                );
+    }
+
+    /**
+     * Wraps the returned object with a standard response wrapper
+     *
+     * @param body                  The returned object from the controller
+     * @param returnType            ?
+     * @param selectedContentType   The media type designation for the endpoint
+     * @param selectedConverterType The class type of the returned object
+     * @param request               The associated http request object
+     * @param response              The associated http response object
+     * @return The object returned by the controller, wrapped in a standard response wrapper.
+     * @throws InternalServiceException If the returned object does not implement serializable
+     */
+    @Override
+    public RestResponse<Serializable> beforeBodyWrite(Object body, MethodParameter returnType, MediaType selectedContentType, Class selectedConverterType, ServerHttpRequest request, ServerHttpResponse response) {
+        if (body instanceof Serializable) {
+            return new RestResponse<>((Serializable) body);
+        } else {
+            throw new InternalServiceException("Response object was invalid type");
+        }
+    }
+
+}

--- a/src/main/java/dev/codesupport/web/common/service/service/CrudOperations.java
+++ b/src/main/java/dev/codesupport/web/common/service/service/CrudOperations.java
@@ -72,14 +72,14 @@ public class CrudOperations<E extends IdentifiableEntity<I>, I, D extends Abstra
 
         AbstractPersistenceValidation<E, I, D, JpaRepository<E, I>> validationToReturn = null;
 
-        //rawtypes - Cant help it, getting them from spring.
+        //rawtypes - This is fine for this logic.
         //noinspection rawtypes
         Map<String, AbstractPersistenceValidation> beans = context.getBeansOfType(AbstractPersistenceValidation.class);
 
-        //rawtypes - Cant help it, getting them from spring.
+        //rawtypes - This is fine for this logic.
         //noinspection rawtypes
         for (Map.Entry<String, AbstractPersistenceValidation> bean : beans.entrySet()) {
-            //rawtypes - Cant help it, getting them from spring.
+            //rawtypes - This is fine for this logic.
             //noinspection rawtypes
             AbstractPersistenceValidation validationBean = bean.getValue();
             if (
@@ -100,14 +100,14 @@ public class CrudOperations<E extends IdentifiableEntity<I>, I, D extends Abstra
      * @param id The id of the desired resource data
      * @return The resource data list for the given id
      */
-    public List<D> getById(I id) {
+    public D getById(I id) {
         Optional<E> object = jpaRepository.findById(id);
 
         if (!object.isPresent()) {
             throw new ResourceNotFoundException(ResourceNotFoundException.Reason.NOT_FOUND);
         }
 
-        return Collections.singletonList(MappingUtils.convertToType(object.get(), domainClass));
+        return MappingUtils.convertToType(object.get(), domainClass);
     }
 
     /**

--- a/src/main/java/dev/codesupport/web/domain/OkResponse.java
+++ b/src/main/java/dev/codesupport/web/domain/OkResponse.java
@@ -1,0 +1,14 @@
+package dev.codesupport.web.domain;
+
+import lombok.Data;
+
+import java.io.Serializable;
+
+@Data
+public class OkResponse implements Serializable {
+
+    //S1170 - Doesn't serialize correctly if made static.
+    @SuppressWarnings({"squid:S1170"})
+    private final String status = "ok";
+
+}

--- a/src/main/java/dev/codesupport/web/domain/TokenResponse.java
+++ b/src/main/java/dev/codesupport/web/domain/TokenResponse.java
@@ -1,0 +1,16 @@
+package dev.codesupport.web.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TokenResponse implements Serializable {
+
+    private String token;
+
+}

--- a/src/test/java/dev/codesupport/web/api/controller/UserControllerImplTest.java
+++ b/src/test/java/dev/codesupport/web/api/controller/UserControllerImplTest.java
@@ -3,10 +3,10 @@ package dev.codesupport.web.api.controller;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import dev.codesupport.web.common.service.service.RestResponse;
-import dev.codesupport.web.domain.User;
 import dev.codesupport.testutils.builders.UserBuilder;
 import dev.codesupport.web.api.service.UserService;
+import dev.codesupport.web.domain.TokenResponse;
+import dev.codesupport.web.domain.User;
 import dev.codesupport.web.domain.UserRegistration;
 import dev.codesupport.web.domain.UserStripped;
 import org.junit.Before;
@@ -68,17 +68,16 @@ public class UserControllerImplTest {
         List<User> userList = userBuilders.stream()
                 .map(UserBuilder::buildDomain).collect(Collectors.toList());
 
-        List<UserStripped> returnedUsers = mapper().convertValue(userList, new TypeReference<List<UserStripped>>() {
+        List<UserStripped> expected = mapper().convertValue(userList, new TypeReference<List<UserStripped>>() {
         });
 
-        doReturn(returnedUsers)
+        doReturn(expected)
                 .when(mockService)
                 .findAllUsers();
 
-        RestResponse<UserStripped> expected = new RestResponse<>(returnedUsers);
-        RestResponse<UserStripped> actual = controller.getAllUsers();
+        List<UserStripped> actual = controller.getAllUsers();
 
-        assertEquals(expected.getResponse(), actual.getResponse());
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -91,31 +90,31 @@ public class UserControllerImplTest {
         List<UserStripped> returnedUsers = mapper().convertValue(userList, new TypeReference<List<UserStripped>>() {
         });
 
-        doReturn(returnedUsers)
+        doReturn(returnedUsers.get(0))
                 .when(mockService)
                 .getUserById(id);
 
-        RestResponse<UserStripped> expected = new RestResponse<>(returnedUsers);
-        RestResponse<UserStripped> actual = controller.getUserById(id);
+        UserStripped expected = returnedUsers.get(0);
+        UserStripped actual = controller.getUserById(id);
 
-        assertEquals(expected.getResponse(), actual.getResponse());
+        assertEquals(expected, actual);
     }
 
     @Test
     public void shouldReturnCorrectResponseForRegisterUser() {
-        List<String> token = Collections.singletonList("Tokentokentoken");
+        String token = "Tokentokentoken";
+        TokenResponse expected = new TokenResponse(token);
 
         UserRegistration userRegistration = new UserRegistration();
         userRegistration.setAlias("user");
 
-        doReturn(token)
+        doReturn(expected)
                 .when(mockService)
                 .registerUser(userRegistration);
 
-        RestResponse<String> expected = new RestResponse<>(token);
-        RestResponse<String> actual = controller.registerUser(userRegistration);
+        TokenResponse actual = controller.registerUser(userRegistration);
 
-        assertEquals(expected.getResponse(), actual.getResponse());
+        assertEquals(expected, actual);
     }
 
 }

--- a/src/test/java/dev/codesupport/web/api/controller/UserProfileControllerImplTest.java
+++ b/src/test/java/dev/codesupport/web/api/controller/UserProfileControllerImplTest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.codesupport.testutils.builders.UserBuilder;
 import dev.codesupport.web.api.service.UserService;
-import dev.codesupport.web.common.service.service.RestResponse;
 import dev.codesupport.web.domain.User;
 import dev.codesupport.web.domain.UserProfile;
 import dev.codesupport.web.domain.UserProfileStripped;
@@ -68,18 +67,17 @@ public class UserProfileControllerImplTest {
         List<User> userList = userBuilders.stream()
                 .map(UserBuilder::buildDomain).collect(Collectors.toList());
 
-        List<UserProfileStripped> returnedUsers = mapper()
+        List<UserProfileStripped> expected = mapper()
                 .convertValue(userList, new TypeReference<List<UserProfileStripped>>() {
                 });
 
-        doReturn(returnedUsers)
+        doReturn(expected)
                 .when(mockService)
                 .findAllUserProfiles();
 
-        RestResponse<UserProfileStripped> expected = new RestResponse<>(returnedUsers);
-        RestResponse<UserProfileStripped> actual = controller.getAllUserProfiles();
+        List<UserProfileStripped> actual = controller.getAllUserProfiles();
 
-        assertEquals(expected.getResponse(), actual.getResponse());
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -89,17 +87,16 @@ public class UserProfileControllerImplTest {
         List<User> userList = userBuilders.stream()
                 .map(UserBuilder::buildDomain).collect(Collectors.toList());
 
-        UserProfile returnedUser = mapper()
+        UserProfile expected = mapper()
                 .convertValue(userList.get(0), UserProfile.class);
 
-        doReturn(returnedUser)
+        doReturn(expected)
                 .when(mockService)
                 .getUserProfileByAlias(alias);
 
-        RestResponse<UserProfile> expected = new RestResponse<>(returnedUser);
-        RestResponse<UserProfile> actual = controller.getUserProfileByAlias(alias);
+        UserProfile actual = controller.getUserProfileByAlias(alias);
 
-        assertEquals(expected.getResponse(), actual.getResponse());
+        assertEquals(expected, actual);
     }
 
     @Test
@@ -113,14 +110,14 @@ public class UserProfileControllerImplTest {
                 .convertValue(userList, new TypeReference<List<UserProfileStripped>>() {
                 });
 
-        doReturn(returnedUsers)
+        doReturn(returnedUsers.get(0))
                 .when(mockService)
                 .getUserProfileById(id);
 
-        RestResponse<UserProfileStripped> expected = new RestResponse<>(returnedUsers);
-        RestResponse<UserProfileStripped> actual = controller.getUserProfileById(id);
+        UserProfileStripped expected = returnedUsers.get(0);
+        UserProfileStripped actual = controller.getUserProfileById(id);
 
-        assertEquals(expected.getResponse(), actual.getResponse());
+        assertEquals(expected, actual);
     }
 
 }

--- a/src/test/java/dev/codesupport/web/api/service/UserServiceImplTest.java
+++ b/src/test/java/dev/codesupport/web/api/service/UserServiceImplTest.java
@@ -9,6 +9,7 @@ import dev.codesupport.web.api.data.repository.UserRepository;
 import dev.codesupport.web.common.security.hashing.HashingUtility;
 import dev.codesupport.web.common.security.jwt.JwtUtility;
 import dev.codesupport.web.common.service.service.CrudOperations;
+import dev.codesupport.web.domain.TokenResponse;
 import dev.codesupport.web.domain.User;
 import dev.codesupport.web.domain.UserProfile;
 import dev.codesupport.web.domain.UserProfileStripped;
@@ -138,15 +139,16 @@ public class UserServiceImplTest {
     public void shouldReturnCorrectUsersWithGetUserProfileById() {
         Long id = 1L;
 
-        List<UserProfileStripped> expected = mapper()
+        List<UserProfileStripped> returnedUsers = mapper()
                 .convertValue(getUserList, new TypeReference<List<UserProfileStripped>>() {
                 });
 
-        doReturn(expected)
+        doReturn(returnedUsers.get(0))
                 .when(mockUserProfileCrudOperations)
                 .getById(id);
 
-        List<UserProfileStripped> actual = service.getUserProfileById(id);
+        UserProfileStripped expected = returnedUsers.get(0);
+        UserProfileStripped actual = service.getUserProfileById(id);
 
         assertEquals(expected, actual);
     }
@@ -170,15 +172,16 @@ public class UserServiceImplTest {
     public void shouldReturnCorrectUsersWithGetUserById() {
         Long id = 1L;
 
-        List<UserStripped> expected = mapper()
+        List<UserStripped> returnedUsers = mapper()
                 .convertValue(getUserList, new TypeReference<List<UserStripped>>() {
                 });
 
-        doReturn(getUserList)
+        doReturn(getUserList.get(0))
                 .when(mockUserCrudOperations)
                 .getById(id);
 
-        List<UserStripped> actual = service.getUserById(id);
+        UserStripped expected = returnedUsers.get(0);
+        UserStripped actual = service.getUserById(id);
 
         assertEquals(expected, actual);
     }
@@ -202,9 +205,10 @@ public class UserServiceImplTest {
                 .when(mockJwtUtility)
                 .generateToken(getUserList.get(0).getAlias(), getUserList.get(0).getEmail());
 
-        List<String> actual = service.registerUser(userRegistration);
+        TokenResponse expected = new TokenResponse(token);
+        TokenResponse actual = service.registerUser(userRegistration);
 
-        assertEquals(Collections.singletonList(token), actual);
+        assertEquals(expected, actual);
     }
 
 }

--- a/src/test/java/dev/codesupport/web/common/security/AuthorizationServiceImplTest.java
+++ b/src/test/java/dev/codesupport/web/common/security/AuthorizationServiceImplTest.java
@@ -13,6 +13,7 @@ import dev.codesupport.web.common.security.models.UserDetails;
 import dev.codesupport.web.common.service.http.HttpClient;
 import dev.codesupport.web.common.service.http.HttpMethod;
 import dev.codesupport.web.common.service.http.RestRequest;
+import dev.codesupport.web.domain.TokenResponse;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -179,9 +180,10 @@ public class AuthorizationServiceImplTest {
                         email
                 );
 
-        String actual = spyService.createTokenForEmailAndPassword(email, password);
+        TokenResponse expected = new TokenResponse(token);
+        TokenResponse actual = spyService.createTokenForEmailAndPassword(email, password);
 
-        assertEquals(token, actual);
+        assertEquals(expected, actual);
     }
 
     @Test(expected = InvalidUserException.class)

--- a/src/test/java/dev/codesupport/web/common/service/controller/AuthenticationControllerImplTest.java
+++ b/src/test/java/dev/codesupport/web/common/service/controller/AuthenticationControllerImplTest.java
@@ -2,15 +2,11 @@ package dev.codesupport.web.common.service.controller;
 
 import dev.codesupport.web.common.exception.InvalidUserException;
 import dev.codesupport.web.common.exception.ServiceLayerException;
-import dev.codesupport.web.common.security.models.AuthenticationRequest;
 import dev.codesupport.web.common.security.AuthorizationService;
-import dev.codesupport.web.common.service.service.RestResponse;
+import dev.codesupport.web.common.security.models.AuthenticationRequest;
+import dev.codesupport.web.domain.OkResponse;
+import dev.codesupport.web.domain.TokenResponse;
 import org.junit.Test;
-import org.springframework.http.ResponseEntity;
-
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doReturn;
@@ -52,6 +48,7 @@ public class AuthenticationControllerImplTest {
         String email = "user@domain.com";
         String password = "clearpassword";
         String token = "mytokenstring";
+        TokenResponse expected = new TokenResponse(token);
 
         AuthenticationRequest request = new AuthenticationRequest();
         request.setEmail(email);
@@ -59,7 +56,7 @@ public class AuthenticationControllerImplTest {
 
         AuthorizationService mockAuthorizationService = mock(AuthorizationService.class);
 
-        doReturn(token)
+        doReturn(expected)
                 .when(mockAuthorizationService)
                 .createTokenForEmailAndPassword(
                         request.getEmail(),
@@ -68,17 +65,9 @@ public class AuthenticationControllerImplTest {
 
         AuthenticationControllerImpl spyController = spy(new AuthenticationControllerImpl(mockAuthorizationService));
 
-        //unchecked - This is fine for creating mocks.
-        //noinspection unchecked
-        RestResponse<String> mockRestResponse = mock(RestResponse.class);
+        TokenResponse response = spyController.authenticate(request);
 
-        doReturn(mockRestResponse)
-                .when(spyController)
-                .getRestResponse(Collections.singletonList(token));
-
-        ResponseEntity<RestResponse<String>> response = spyController.authenticate(request);
-
-        assertEquals(mockRestResponse, response.getBody());
+        assertEquals(expected, response);
     }
 
     @Test(expected = ServiceLayerException.class)
@@ -118,31 +107,8 @@ public class AuthenticationControllerImplTest {
 
         AuthenticationControllerImpl controller = new AuthenticationControllerImpl(mockAuthorizationService);
 
-        List<String> expected = Collections.singletonList("Ok");
-
-        ResponseEntity<RestResponse<Serializable>> responseEntity = controller.linkDiscord(code);
-
-        //ConstantConditions - This is fine for the context of this test.
-        //noinspection ConstantConditions
-        assertEquals(expected, responseEntity.getBody().getResponse());
-    }
-
-    @Test
-    public void shouldCreateCorrectRestResponseObject() {
-        String referenceId = "1234";
-
-        AuthorizationService mockAuthorizationService = mock(AuthorizationService.class);
-
-        AuthenticationControllerImpl controller = new AuthenticationControllerImpl(mockAuthorizationService);
-
-        List<String> token = Collections.singletonList("tokentokentoken");
-
-        RestResponse<String> expected = new RestResponse<>();
-        expected.setReferenceId(referenceId);
-        expected.setResponse(token);
-
-        RestResponse<String> actual = controller.getRestResponse(token);
-        actual.setReferenceId(referenceId);
+        OkResponse expected = new OkResponse();
+        OkResponse actual = controller.linkDiscord(code);
 
         assertEquals(expected, actual);
     }

--- a/src/test/java/dev/codesupport/web/common/service/controller/HealthCheckControllerTest.java
+++ b/src/test/java/dev/codesupport/web/common/service/controller/HealthCheckControllerTest.java
@@ -1,10 +1,7 @@
 package dev.codesupport.web.common.service.controller;
 
-import dev.codesupport.web.common.service.service.RestResponse;
+import dev.codesupport.web.domain.OkResponse;
 import org.junit.Test;
-
-import java.io.Serializable;
-import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 
@@ -14,9 +11,10 @@ public class HealthCheckControllerTest {
     public void shouldReturnNullResponseForHealthCheck() {
         HealthCheckController controller = new HealthCheckController();
 
-        RestResponse<Serializable> actual = controller.getHealthCheck();
+        OkResponse expected = new OkResponse();
+        OkResponse actual = controller.getHealthCheck();
 
-        assertEquals(Collections.emptyList(), actual.getResponse());
+        assertEquals(expected, actual);
     }
 
 }

--- a/src/test/java/dev/codesupport/web/common/service/service/CrudOperationsTest.java
+++ b/src/test/java/dev/codesupport/web/common/service/service/CrudOperationsTest.java
@@ -112,7 +112,7 @@ public class CrudOperationsTest {
 
         //rawtypes - Fine for the purposes of this test.
         //noinspection rawtypes
-        AbstractPersistenceValidation actual = (AbstractPersistenceValidation)ReflectionTestUtils.getField(crudOperationsSpy, "validation");
+        AbstractPersistenceValidation actual = (AbstractPersistenceValidation) ReflectionTestUtils.getField(crudOperationsSpy, "validation");
 
         assertEquals(mockValidator, actual);
     }
@@ -134,9 +134,10 @@ public class CrudOperationsTest {
                 .when(mockRepository)
                 .findById(id);
 
-        List<MockDomain> actual = crudOperationsSpy.getById(id);
+        MockDomain expected = domainsToReturn.get(0);
+        MockDomain actual = crudOperationsSpy.getById(id);
 
-        assertEquals(domainsToReturn, actual);
+        assertEquals(expected, actual);
     }
 
     @Test(expected = ResourceNotFoundException.class)


### PR DESCRIPTION
Remove need to explicitly wrap controller responses with standard response wrapper
All responses (except excluded ones, such as errorhandler) will be auto-wrapped with a standard response

This is just cleaner and easier on developers