### PR TITLE
Disable SSL requirements at an application level

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -14,15 +14,8 @@ spring:
     open-in-view: false
     hibernate:
       ddl-auto: none
-security:
-  require-ssl: true
 server:
   port: ${service.port:8080}
-  ssl:
-    key-store: ${ssl.key.store:}
-    key-store-password: ${ssl.key.store.password:}
-    keyStoreType: ${ssl.key.store.type:PKCS12}
-    keyAlias: ${ssl.key.alias:tomcat}
 healthcheck:
   ping:
     url: ${hc.ping.url:}


### PR DESCRIPTION
# Disable SSL
This PR disables SSL within the springboot (/ tomcat) application in favour of managing the SSL certifications at a higher level with nginx.